### PR TITLE
Fix Container Reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+# JetBrains IDEs
+.idea

--- a/Ductus.FluentDocker.Tests/FluentApiTests/FluentContainerBasicTests.cs
+++ b/Ductus.FluentDocker.Tests/FluentApiTests/FluentContainerBasicTests.cs
@@ -375,5 +375,23 @@ namespace Ductus.FluentDocker.Tests.FluentApiTests
         }
       }
     }
+
+    [TestMethod]
+    public void ReuseOfExistingContainerShallWork()
+    {
+      using (new Builder()
+        .UseContainer()
+        .UseImage("postgres:9.6-alpine")
+        .WithName("reusable-name")
+        .Build())
+      using (new Builder()
+        .UseContainer()
+        .ReuseIfExists()
+        .UseImage("postgres:9.6-alpine")
+        .WithName("reusable-name")
+        .Build())
+      {
+      }
+    }
   }
 }

--- a/Ductus.FluentDocker/Builders/ContainerBuilder.cs
+++ b/Ductus.FluentDocker/Builders/ContainerBuilder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Text.RegularExpressions;
 using Ductus.FluentDocker.Common;
 using Ductus.FluentDocker.Extensions;
 using Ductus.FluentDocker.Model.Builders;
@@ -32,8 +33,8 @@ namespace Ductus.FluentDocker.Builders
       {
         // Since filter on docker is only prefix filter
         var existing =
-          host.Value.GetContainers(true, $" -f name={_config.CreateParams.Name}")
-            .FirstOrDefault(x => x.Name == _config.CreateParams.Name);
+          host.Value.GetContainers(true, $"name={_config.CreateParams.Name}")
+            .FirstOrDefault(x => IsNameMatch(x.Name, _config.CreateParams.Name));
 
         if (null != existing)
         {
@@ -321,5 +322,8 @@ namespace Ductus.FluentDocker.Builders
         });
       }
     }
+
+    private static bool IsNameMatch(string containerName, string test) =>
+      Regex.IsMatch(containerName, $@"^\/?{test}$");
   }
 }

--- a/Ductus.FluentDocker/Services/Impl/DockerHostService.cs
+++ b/Ductus.FluentDocker/Services/Impl/DockerHostService.cs
@@ -145,7 +145,7 @@ namespace Ductus.FluentDocker.Services.Impl
 
       if (!string.IsNullOrEmpty(filter))
       {
-        options += $" --filter={filter}";
+        options += $" --filter {filter}";
       }
 
       var result = Host.Ps(options, Certificates);


### PR DESCRIPTION
Fixed filtering of existing containers based on the given name:

1) Filter was composed incorrectly (`--filter=-f name=…`), now it's `--filter name=…`.

2) On my machine `docker inspect` returns container names in `/container-name` format, so name check is a bit more involved now.