### PR TITLE
Add model support for returning health check in config.

### DIFF
--- a/Ductus.FluentDocker.Tests/FluentApiTests/FluentContainerBasicTests.cs
+++ b/Ductus.FluentDocker.Tests/FluentApiTests/FluentContainerBasicTests.cs
@@ -7,6 +7,7 @@ using Ductus.FluentDocker.Commands;
 using Ductus.FluentDocker.Extensions;
 using Ductus.FluentDocker.Model.Builders;
 using Ductus.FluentDocker.Model.Common;
+using Ductus.FluentDocker.Model.Containers;
 using Ductus.FluentDocker.Services;
 using Ductus.FluentDocker.Services.Extensions;
 using Ductus.FluentDocker.Tests.Extensions;
@@ -457,6 +458,23 @@ namespace Ductus.FluentDocker.Tests.FluentApiTests
       {
         var config = container.GetConfiguration(true);
         AreEqual(ServiceRunningState.Running, config.State.ToServiceState());
+      }
+    }
+    
+    [TestMethod]
+    public void ContainerHealthCheckShallWork()
+    {
+      using (
+        var container =
+          Fd.UseContainer()
+            .UseImage("postgres:latest", force: true)
+            .HealthCheck("exit")
+            .WithEnvironment("POSTGRES_PASSWORD=mysecretpassword")
+            .Build()
+            .Start())
+      {
+        var config = container.GetConfiguration(true);
+        AreEqual(HealthState.Starting, config.State.Health.Status);
       }
     }
   }

--- a/Ductus.FluentDocker/Builders/ContainerBuilder.cs
+++ b/Ductus.FluentDocker/Builders/ContainerBuilder.cs
@@ -228,6 +228,12 @@ namespace Ductus.FluentDocker.Builders
       return this;
     }
 
+    public ContainerBuilder HealthCheck(string cmd)
+    {
+      _config.CreateParams.HealthCheck = cmd;
+      return this;
+    }
+
     public ContainerBuilder Mount(string fqHostPath, string fqContainerPath, MountType access)
     {
       var hp = FdOs.IsWindows() && CommandExtensions.IsToolbox()

--- a/Ductus.FluentDocker/Model/Containers/ContainerCreateParams.cs
+++ b/Ductus.FluentDocker/Model/Containers/ContainerCreateParams.cs
@@ -519,6 +519,14 @@ namespace Ductus.FluentDocker.Model.Containers
     ///   -w, --workdir
     /// </remarks>
     public string WorkingDirectory { get; set; }
+    
+    /// <summary>
+    /// Health check for container
+    /// </summary>
+    /// <remarks>
+    ///  --health-cmd
+    /// </remarks>
+    public string HealthCheck { get; set; }
 
     /// <summary>
     ///   Publish a container's port(s) to the host
@@ -755,7 +763,7 @@ namespace Ductus.FluentDocker.Model.Containers
       else
         sb.Append(" -P");
 
-      
+      sb.OptionIfExists("--health-cmd=", HealthCheck);
       sb.OptionIfExists("--cgroup-parent ", ParentCGroup);      
       sb.OptionIfExists("-e ", Environment);
       sb.OptionIfExists("--env-file=", EnvironmentFiles);

--- a/Ductus.FluentDocker/Model/Containers/ContainerState.cs
+++ b/Ductus.FluentDocker/Model/Containers/ContainerState.cs
@@ -17,5 +17,6 @@ namespace Ductus.FluentDocker.Model.Containers
     public string Error { get; set; }
     public DateTime StartedAt { get; set; }
     public DateTime FinishedAt { get; set; }
+    public Health Health { get; set; }
   }
 }

--- a/Ductus.FluentDocker/Model/Containers/Health.cs
+++ b/Ductus.FluentDocker/Model/Containers/Health.cs
@@ -1,0 +1,8 @@
+namespace Ductus.FluentDocker.Model.Containers
+{
+    public class Health
+    {
+        public HealthState Status { get; set; }
+        public int FailingStreak { get; set; }
+    }
+}

--- a/Ductus.FluentDocker/Model/Containers/HealthState.cs
+++ b/Ductus.FluentDocker/Model/Containers/HealthState.cs
@@ -1,0 +1,10 @@
+namespace Ductus.FluentDocker.Model.Containers
+{
+    public enum HealthState
+    {
+        Starting,
+        Unhealthy,
+        Healthy,
+        Unknown
+    }
+}


### PR DESCRIPTION
A common feature in Dockerfiles is to define a custom health check. This PR includes the ability to return some basic health check information from the existing `GetConfiguration()` command.

In order to include a test to cover this new model mapping, a new method `.HealthCheck(string command)` has been added to the `ContainerBuilder` since the `postgress` image used for testing doesnt expose a health configuration of its own.