### PR TITLE
Update ExitCode to long. 

### DIFF
--- a/Ductus.FluentDocker/Model/Containers/ContainerState.cs
+++ b/Ductus.FluentDocker/Model/Containers/ContainerState.cs
@@ -13,7 +13,7 @@ namespace Ductus.FluentDocker.Model.Containers
     public bool OOMKilled { get; set; }
     public bool Dead { get; set; }
     public int Pid { get; set; }
-    public int ExitCode { get; set; }
+    public long ExitCode { get; set; }
     public string Error { get; set; }
     public DateTime StartedAt { get; set; }
     public DateTime FinishedAt { get; set; }


### PR DESCRIPTION
Windows Containers sometimes exit with 3221225725 (depending on the method of process exiting) causing parsing error in Json.Net.

I am happy if you would like to discuss other solutions to this bug.

e.g.
> docker inspect 2b8

returns
```
[
    {
        "Id": "2b832e9e8d82158162d0cd289900f951c0074d496003b649965f7631f4855d78",
        "Created": "2019-07-21T00:27:12.1995388Z",
        "Path": "powershell",
        "Args": [ ],
        "State": {
            "Status": "exited",
            "Running": false,
            "Paused": false,
            "Restarting": false,
            "OOMKilled": false,
            "Dead": false,
            "Pid": 0,
            "ExitCode": 3221225786,
            "Error": "",
            "StartedAt": "2019-07-21T00:27:18.5270944Z",
            "FinishedAt": "2019-07-21T10:29:56.1215523+10:00",
...
```

which fluentDocker then throws with


```
Unhandled Exception: Newtonsoft.Json.JsonReaderException: JSON integer 3221225786 is too large or small for an Int32. Path 'State.ExitCode', line 17, position 34.
   at Newtonsoft.Json.JsonTextReader.ParseReadNumber(ReadType readType, Char firstChar, Int32 initialPosition)
   at Newtonsoft.Json.JsonTextReader.ParseNumber(ReadType readType)
   at Newtonsoft.Json.JsonTextReader.ReadNumberValue(ReadType readType)
   at Newtonsoft.Json.JsonTextReader.ReadAsInt32()
   at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, Jso
nProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContra
ct, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerP
roperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, Jso
nProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContra
ct, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value)
   at Ductus.FluentDocker.Executors.Parsers.ClientContainerInspectCommandResponder.Process(ProcessExecutionResult response)
   at Ductus.FluentDocker.Executors.ProcessExecutor`2.Execute()
   at Ductus.FluentDocker.Commands.Client.InspectContainer(DockerUri host, String id, ICertificatePaths certificates)
   at Ductus.FluentDocker.Services.Impl.DockerContainerService.GetConfiguration(Boolean fresh)
   at Ductus.FluentDocker.Extensions.ServiceExtensions.Callback(Object state)

```