### PR TITLE
Running containers must not be stopped unless force is used (Issue #113)

### DIFF
--- a/Ductus.FluentDocker/Services/Impl/DockerContainerService.cs
+++ b/Ductus.FluentDocker/Services/Impl/DockerContainerService.cs
@@ -145,7 +145,7 @@ namespace Ductus.FluentDocker.Services.Impl
 
     public void Remove(bool force = false)
     {
-      if (State != ServiceRunningState.Stopped)
+      if (State != ServiceRunningState.Stopped && force)
         Stop();
 
       State = ServiceRunningState.Removing;
@@ -195,7 +195,7 @@ namespace Ductus.FluentDocker.Services.Impl
 
     private void Remove(bool force, bool removeVolume)
     {
-      if (State != ServiceRunningState.Stopped)
+      if (State != ServiceRunningState.Stopped && force)
         Stop();
 
       State = ServiceRunningState.Removing;


### PR DESCRIPTION
TL;DR:
Removing a `RUNNING` docker container must not be allowed, unless `force=true` is used.

----

During #113 I've noticed that executing:

```
Environment.SetEnvironmentVariable("DOCKER_HOST", "ax-docker02:2375");
var composition = new Builder()
                    .UseContainer()
                    .UseCompose()
                    .FromFile("testcase1.yml")
                    .Build();

composition.Start();

composition.Containers.ToList().ForEach(c => c.Remove()); // force = false
```

will remove `RUNNING` containers, although the optional `force` parameter is not used.

The API shall reflect the behavior of the docker client, where `docker rm <containerid>` is not permitted if the container is running.