### PR TITLE
Fix health check FluentAPI

### DIFF
--- a/Ductus.FluentDocker/Builders/ContainerBuilder.cs
+++ b/Ductus.FluentDocker/Builders/ContainerBuilder.cs
@@ -293,7 +293,7 @@ namespace Ductus.FluentDocker.Builders
     public ContainerBuilder UseHealthCheck(string cmd = null, string interval = null, string timeout = null, string startPeriod = null, int retries = -1)
     {
       if (!string.IsNullOrEmpty(cmd))
-      _config.CreateParams.HealthCheckCmd = cmd;
+        _config.CreateParams.HealthCheckCmd = cmd;
 
       if (!string.IsNullOrEmpty(interval))
         _config.CreateParams.HealthCheckInterval = interval;

--- a/Ductus.FluentDocker/Builders/ContainerBuilder.cs
+++ b/Ductus.FluentDocker/Builders/ContainerBuilder.cs
@@ -546,6 +546,19 @@ namespace Ductus.FluentDocker.Builders
       return this;
     }
 
+    /// <summary>
+    /// This install a wait for a docker daemon HEALTH check until certain timeout to set to Healthy.
+    /// </summary>
+    /// <param name="timeout">A optional timeout to stop waiting.</param>
+    /// <returns>Itself for fluent access.</returns>
+    /// <remarks>
+    ///   When the container is in <see cref="ServiceRunningState.Running"/> mode it will poll
+    ///   the container configuration and check the health of the container (as classified by the
+    ///   docker daemon). When the container is reported as Healthy, this method silently exits.
+    ///   If timeout a <see cref="FluentDockerException"/> is thrown. The status is deemed
+    ///   by the containers Dockerfiles HEALTH section or if overrided / created by
+    ///   <see cref="UseHealthCheck(string, string, string, string, int)"/>.
+    /// </remarks>
     public ContainerBuilder WaitForHealthy(TimeSpan timeout = default)
     {
       if (timeout == default)

--- a/Ductus.FluentDocker/Builders/ContainerBuilder.cs
+++ b/Ductus.FluentDocker/Builders/ContainerBuilder.cs
@@ -256,9 +256,57 @@ namespace Ductus.FluentDocker.Builders
       return this;
     }
 
+    /// <summary>
+    /// Deprecated ue <see cref="UseHealthCheck(string, string, string, int)"/> instead.
+    /// </summary>
+    /// <param name="cmd">Commnad to use in the health check.</param>
+    /// <returns>Itself for fluent access</returns>
+    [Deprecated("Will be removed since replaced by UseHealthCheck")]
     public ContainerBuilder HealthCheck(string cmd)
     {
-      _config.CreateParams.HealthCheck = cmd;
+      return UseHealthCheck(cmd);
+    }
+
+    /// <summary>
+    /// Completely disable HEALTHCHECK.
+    /// </summary>
+    /// <returns>Itself for fluent access.</returns>
+    /// <remarks>
+    /// Independant on what is specified in the Dockerfile (in HEALTHCHECK section).
+    /// All is disabled!
+    /// </remarks>
+    public ContainerBuilder UseNoHealthCheck()
+    {
+      _config.CreateParams.HealthCheckDisabled = true;
+      return this;
+    }
+
+    /// <summary>
+    /// Sets or overrides the native HEALTHCHECK provided by the docker daemon.
+    /// </summary>
+    /// <param name="cmd">A commnad to preform the health check.</param>
+    /// <param name="interval">How ofthen to perform the <paramref name="cmd"/>, default is 30s.</param>
+    /// <param name="timeout">How long time the <paramref name="cmd"/> has in order to not be marked as unhealthy container.</param>
+    /// <param name="startPeriod">How long for the first execution of <paramref name="cmd"/>, default is 30s.</param>
+    /// <param name="retries">The number of retries a <paramref name="cmd"/> has in order for the container do be marked as unhealthy, default is 3.</param>
+    /// <returns>Itself for fluent access.</returns>
+    public ContainerBuilder UseHealthCheck(string cmd = null, string interval = null, string timeout = null, string startPeriod = null, int retries = -1)
+    {
+      if (!string.IsNullOrEmpty(cmd))
+      _config.CreateParams.HealthCheckCmd = cmd;
+
+      if (!string.IsNullOrEmpty(interval))
+        _config.CreateParams.HealthCheckInterval = interval;
+
+      if (!string.IsNullOrEmpty(timeout))
+        _config.CreateParams.HealthCheckTimeout = timeout;
+
+      if (!string.IsNullOrEmpty(startPeriod))
+        _config.CreateParams.HealthCheckStartPeriod = startPeriod;
+
+      if (retries > 0)
+        _config.CreateParams.HealthCheckRetries = retries;
+
       return this;
     }
 

--- a/Ductus.FluentDocker/Model/Containers/ContainerCreateParams.cs
+++ b/Ductus.FluentDocker/Model/Containers/ContainerCreateParams.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Text;
@@ -532,13 +532,62 @@ namespace Ductus.FluentDocker.Model.Containers
     public string WorkingDirectory { get; set; }
 
     /// <summary>
-    ///   Health check for container
+    ///   Health check command for container
     /// </summary>
     /// <remarks>
+    ///   This defines what command to run in order to check the health status.
+    ///   Health check commands should return 0 if healthy and 1 if unhealthy.
+    ///   Note that the command you use to validate health must be present in the image.
     ///   --health-cmd
     /// </remarks>
-    public string HealthCheck { get; set; }
+    public string HealthCheckCmd { get; set; }
 
+    /// <summary>
+    /// The timeout when the daemon deems a container as unhealthy
+    /// </summary>
+    /// <remarks>
+    ///  If the health check command takes longer than this to complete,
+    ///  it will be considered a failure. The default timeout is 30 seconds.
+    ///  --health-timeout
+    /// </remarks>
+    public string HealthCheckTimeout { get; set; }
+
+    /// <summary>
+    /// The number of retries of the health check commnad <see cref="HealthCheckCmd"/>
+    /// </summary>
+    /// <remarks>
+    ///   The health check will retry up to this many times before marking the container
+    ///   as unhealthy. The default is 3 retries.
+    ///   --health-retries
+    /// </remarks>
+    public int HealthCheckRetries { get; set; } = -1;
+
+    /// <summary>
+    /// The time between the <see cref="HealthCheckCmd"/> is executed.
+    /// </summary>
+    /// <remarks>
+    ///   This controls the initial delay before the first health check runs and then how
+    ///   often the health check command is executed thereafter. The default is 30 seconds.
+    ///   --health-interval
+    /// </remarks>
+    public string HealthCheckInterval { get; set; }
+
+    /// <summary>
+    /// The start <see cref="HealthCheckInterval"/> for the first execution of <see cref="HealthCheckCmd"/>.
+    /// </summary>
+    /// <remarks>
+    ///   The default is 30s.
+    ///   --health-start-period
+    /// </remarks>
+    public string HealthCheckStartPeriod { get; set; }
+
+    /// <summary>
+    /// When set to true, independand on the HEALTHCHECK in the Dockerfile, no health check is performed.
+    /// </summary>
+    /// <remarks>
+    /// --no-healthcheck 
+    /// </remarks>
+    public bool HealthCheckDisabled { get; set; }
     /// <summary>
     ///   Publish a container's port(s) to the host
     /// </summary>
@@ -802,7 +851,17 @@ namespace Ductus.FluentDocker.Model.Containers
       else
         sb.Append(" -P");
 
-      sb.OptionIfExists("--health-cmd=", HealthCheck);
+      // Native health check
+      sb.OptionIfExists("--health-cmd=", HealthCheckCmd);
+      sb.OptionIfExists("--health-interval=", HealthCheckInterval);
+      sb.OptionIfExists("--health-timeout=", HealthCheckTimeout);
+      sb.OptionIfExists("--health-start-period=", HealthCheckStartPeriod);
+      sb.OptionIfExists("--no-healthcheck", HealthCheckDisabled);
+
+      if (HealthCheckRetries > 0)
+        sb.Append($" --health-retries={HealthCheckRetries}");
+
+
       sb.OptionIfExists("--cgroup-parent ", ParentCGroup);
       sb.OptionIfExists("-e ", Environment);
       sb.OptionIfExists("--env-file=", EnvironmentFiles);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,9 +31,9 @@ build:
   verbosity: minimal
 
 artifacts:
-  - path: '**\Release\*.nupkg'
+  - path: '.\**\Release\*.nupkg'
     name: NuGet Packages
-  - path: '**\Release\*.snupkg'
+  - path: '.\**\Release\*.snupkg'
     name: NuGet Symbol Packages
 
 deploy:


### PR DESCRIPTION
This relates to Issue #130 where it was not possible to override **all** aspects of the _HEALTCHECK_ section in runtime.