### PR TITLE
Added support for custom runtime in FluentAPI (Issue #132).

### DIFF
--- a/Ductus.FluentDocker.Tests/Model/Containers/ContainerCreateParamsTests.cs
+++ b/Ductus.FluentDocker.Tests/Model/Containers/ContainerCreateParamsTests.cs
@@ -1,0 +1,18 @@
+using System;
+using Ductus.FluentDocker.Model.Containers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ductus.FluentDocker.Tests.Model.Containers
+{
+  [TestClass]
+  public class ContainerCreateParamsTests
+  {
+    [TestMethod]
+    public void NvidiaRuntimeGeneratesRuntimeOption()
+    {
+      var prms = new ContainerCreateParams { Runtime = ContainerRuntime.Nvidia };
+      var opts = prms.ToString();
+      Assert.IsTrue(opts.Contains(" --runtime=nvidia"));
+    }
+  }
+}

--- a/Ductus.FluentDocker/Builders/ContainerBuilder.cs
+++ b/Ductus.FluentDocker/Builders/ContainerBuilder.cs
@@ -310,6 +310,23 @@ namespace Ductus.FluentDocker.Builders
       return this;
     }
 
+    /// <summary>
+    /// Specifies a container runtime, e.g. NVIDIA for GPU workloads.
+    /// </summary>
+    /// <param name="runtime">A runtime to execute the container under.</param>
+    /// <returns>Itself for fluent access.</returns>
+    /// <remarks>
+    /// By default, containers execute under docker provided default environment
+    /// <see cref="ContainerRuntime.Default"/>. It is not neccesary to specify
+    /// such. Instead, if a custom runtime is wanted for the container specify custom
+    /// runtime such as <see cref="ContainerRuntime.Nvidia"/>.
+    /// </remarks>
+    public ContainerBuilder UseRuntime(ContainerRuntime runtime)
+    {
+      _config.CreateParams.Runtime = runtime;
+      return this;
+    }
+
     public ContainerBuilder Mount(string fqHostPath, string fqContainerPath, MountType access)
     {
       var hp = FdOs.IsWindows() && CommandExtensions.IsToolbox()

--- a/Ductus.FluentDocker/Model/Containers/ContainerCreateParams.cs
+++ b/Ductus.FluentDocker/Model/Containers/ContainerCreateParams.cs
@@ -799,6 +799,11 @@ namespace Ductus.FluentDocker.Model.Containers
     public IList<ULimitItem> Ulimit { get; } = new List<ULimitItem>();
 
     /// <summary>
+    /// Specify a container runtime. Default is docker built-in.
+    /// </summary>
+    public ContainerRuntime Runtime { get; set; } = ContainerRuntime.Default;
+
+    /// <summary>
     ///   Renders the argument string from this instance.
     /// </summary>
     /// <returns></returns>
@@ -922,6 +927,9 @@ namespace Ductus.FluentDocker.Model.Containers
       if (CpuShares != int.MinValue)
         sb.Append($" --cpu-shares=\"{CpuShares}\"");
 
+      // Runtime
+      if (Runtime != ContainerRuntime.Default)
+        sb.Append($" --runtime={Runtime.ToString().ToLower()}");
 
       return sb.ToString();
     }

--- a/Ductus.FluentDocker/Model/Containers/ContainerRuntime.cs
+++ b/Ductus.FluentDocker/Model/Containers/ContainerRuntime.cs
@@ -1,0 +1,18 @@
+namespace Ductus.FluentDocker.Model.Containers
+{
+  public enum ContainerRuntime
+  {
+    /// <summary>
+    /// Default runtime provided with docker. This is the
+    /// default and is not neccesary to specify.
+    /// </summary>
+    Default = 0,
+    /// <summary>
+    /// The NVIDIA container runtime to utlitize the GPU.
+    /// </summary>
+    /// <remarks>
+    /// See https://github.com/NVIDIA/nvidia-docker/wiki/Usage for usage.
+    /// </remarks>
+    Nvidia = 1
+  }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ dotnet_csproj:
   informational_version: '{version}'
 
 install:
-  - ps: dotnet tool install -g Codecov.Tool
   - ps: dotnet tool install -g GitVersion.Tool
   - ps: dotnet tool install -g dotnet-format
 


### PR DESCRIPTION
It is now possible to do 
```cs
ContainerBuilder.UseRuntime(ContainerRuntime.Nvidia);
```
this will add _--runtime=nvidia_ when creating the container. The only custom runtime is ContainerRuntime.Nvidia as of now.

This is to solve Issue #132 