### PR TITLE
Add code coverage

### DIFF
--- a/Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj
+++ b/Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="coverlet.collector" Version="1.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
     <PackageReference Include="Npgsql" Version="4.0.7" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,13 @@ install:
   - ps: dotnet tool install -g GitVersion.Tool
   - ps: dotnet tool install -g dotnet-format
   - ps: dotnet tool install -g dotnet-sonarscanner -v:m
+  - ps: dotnet tool install -g coverlet.console --version 1.6.0
 
 before_build:
   - nuget restore
   - ps: dotnet format --check --dry-run
   - ps: dotnet gitversion /l console /output buildserver
+  - ps: coverlet Ductus.FluentDocker.Tests/bin/Debug/netcoreapp3.0/Ductus.FluentDocker.Tests.dll --target "dotnet" --targetargs "test Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj --no-build" --format opencover -o ./output/
   - ps: dotnet sonarscanner begin /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=e220dd372506f00fe34923f011ea45f8568e9bcc /k:mariotoffia_FluentDocker /o:mariotoffia /v:"$env:APPVEYOR_BUILD_NUMBER" /d:sonar.cs.opencover.reportsPaths="./output/coverage.opencover.xml" /d:sonar.coverage.exclusions="**Tests*.cs"
   - ps: $env:good_to_deploy="true"
   - ps: if (Test-Path env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH) {echo "Not going to deploy because pull request."}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,13 +16,12 @@ install:
   - ps: dotnet tool install -g GitVersion.Tool
   - ps: dotnet tool install -g dotnet-format
   - ps: dotnet tool install -g dotnet-sonarscanner -v:m
-  - ps: dotnet tool install -g coverlet.console --version 1.6.0
 
 before_build:
   - nuget restore
   - ps: dotnet format --check --dry-run
   - ps: dotnet gitversion /l console /output buildserver
-  - ps: coverlet Ductus.FluentDocker.Tests/bin/Debug/netcoreapp3.0/Ductus.FluentDocker.Tests.dll --target "dotnet" --targetargs "test Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj --no-build" --format opencover -o ./output/
+  - ps: dotnet test --settings coverletArgs.runsettings
   - ps: dotnet sonarscanner begin /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=e220dd372506f00fe34923f011ea45f8568e9bcc /k:mariotoffia_FluentDocker /o:mariotoffia /v:"$env:APPVEYOR_BUILD_NUMBER" /d:sonar.cs.opencover.reportsPaths="./output/coverage.opencover.xml" /d:sonar.coverage.exclusions="**Tests*.cs"
   - ps: $env:good_to_deploy="true"
   - ps: if (Test-Path env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH) {echo "Not going to deploy because pull request."}

--- a/coverletArgs.runsettings
+++ b/coverletArgs.runsettings
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>xml,opencover</Format>
+          <MergeWith>output/coverage.opencover.xml</MergeWith>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
´dotnet test´ does not run test coverage if one of the tests fail.
coverlet.console is the solution to the failing tests. Unfortunately, you have to point to the tests dll file.
Please, consider adding the code coverage to the project. I personally think it adds value. :)