### PR TITLE
NetworkLs: Fix parsing of CreatedAt

### DIFF
--- a/Ductus.FluentDocker.Tests/ProcessResponseParsersTests/NetworkLsResponseParserTests.cs
+++ b/Ductus.FluentDocker.Tests/ProcessResponseParsersTests/NetworkLsResponseParserTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Reflection;
+using Ductus.FluentDocker.Executors;
+using Ductus.FluentDocker.Executors.Parsers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ductus.FluentDocker.Tests.ProcessResponseParsersTests
+{
+  [TestClass]
+  public class NetworkLsResponseParserTests
+  {
+    [TestMethod]
+    public void ProcessShallParseResponse()
+    {
+      // Arrange
+
+      var id = Guid.NewGuid().ToString();
+      var name = Guid.NewGuid().ToString();
+      var driver = Guid.NewGuid().ToString();
+      var scope = Guid.NewGuid().ToString();
+      var ipv6 = false;
+      var isInternal = true;
+      var created = DateTime.Now.ToUniversalTime();
+
+      var stdOut = $"{id};{name};{driver};{scope};{ipv6};{isInternal};{created:yyyy-MM-dd HH:mm:ss.ffffff} +0000 ZZZ";
+
+      var ctorArgs = new object[] {"command", stdOut, "", 0};
+      var executionResult = (ProcessExecutionResult)Activator.CreateInstance(typeof(ProcessExecutionResult),
+        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.CreateInstance,
+        null, ctorArgs, null, null);
+
+      var parser = new NetworkLsResponseParser();
+
+
+      // Act
+      var result = parser.Process(executionResult).Response.Data[0];
+
+      // Assert
+      Assert.AreEqual(id, result.Id);
+      Assert.AreEqual(name, result.Name);
+      Assert.AreEqual(driver, result.Driver);
+      Assert.AreEqual(scope, result.Scope);
+      Assert.AreEqual(ipv6, result.IPv6);
+      Assert.AreEqual(isInternal, result.Internal);
+      Assert.AreEqual(created, result.Created.ToUniversalTime());
+    }
+
+
+    [TestMethod]
+    public void ProcessShallParseResponseWithNegativeTimezone()
+    {
+      // Arrange
+
+      var tzShift = -3;
+      var id = Guid.NewGuid().ToString();
+      var name = Guid.NewGuid().ToString();
+      var driver = Guid.NewGuid().ToString();
+      var scope = Guid.NewGuid().ToString();
+      var ipv6 = false;
+      var isInternal = true;
+      var created = DateTime.Now;
+
+      var stdOut = $"{id};{name};{driver};{scope};{ipv6};{isInternal};{created:yyyy-MM-dd HH:mm:ss.ffffff} {tzShift:00}00 ZZZ";
+
+      var ctorArgs = new object[] {"command", stdOut, "", 0};
+      var executionResult = (ProcessExecutionResult)Activator.CreateInstance(typeof(ProcessExecutionResult),
+        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.CreateInstance,
+        null, ctorArgs, null, null);
+
+      var parser = new NetworkLsResponseParser();
+
+
+      // Act
+      var result = parser.Process(executionResult).Response.Data[0];
+
+      // Assert
+      Assert.AreEqual(id, result.Id);
+      Assert.AreEqual(name, result.Name);
+      Assert.AreEqual(driver, result.Driver);
+      Assert.AreEqual(scope, result.Scope);
+      Assert.AreEqual(ipv6, result.IPv6);
+      Assert.AreEqual(isInternal, result.Internal);
+      Assert.AreEqual(created, result.Created.AddMinutes(-1 * DateTimeOffset.Now.Offset.TotalMinutes).AddHours(tzShift));
+    }
+  }
+}

--- a/Ductus.FluentDocker.Tests/ProcessResponseParsersTests/NetworkLsResponseParserTests.cs
+++ b/Ductus.FluentDocker.Tests/ProcessResponseParsersTests/NetworkLsResponseParserTests.cs
@@ -24,7 +24,7 @@ namespace Ductus.FluentDocker.Tests.ProcessResponseParsersTests
 
       var stdOut = $"{id};{name};{driver};{scope};{ipv6};{isInternal};{created:yyyy-MM-dd HH:mm:ss.ffffff} +0000 ZZZ";
 
-      var ctorArgs = new object[] {"command", stdOut, "", 0};
+      var ctorArgs = new object[] { "command", stdOut, "", 0 };
       var executionResult = (ProcessExecutionResult)Activator.CreateInstance(typeof(ProcessExecutionResult),
         BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.CreateInstance,
         null, ctorArgs, null, null);
@@ -62,7 +62,7 @@ namespace Ductus.FluentDocker.Tests.ProcessResponseParsersTests
 
       var stdOut = $"{id};{name};{driver};{scope};{ipv6};{isInternal};{created:yyyy-MM-dd HH:mm:ss.ffffff} {tzShift:00}00 ZZZ";
 
-      var ctorArgs = new object[] {"command", stdOut, "", 0};
+      var ctorArgs = new object[] { "command", stdOut, "", 0 };
       var executionResult = (ProcessExecutionResult)Activator.CreateInstance(typeof(ProcessExecutionResult),
         BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.CreateInstance,
         null, ctorArgs, null, null);

--- a/Ductus.FluentDocker/Executors/Parsers/NetworkInspectResponseParser.cs
+++ b/Ductus.FluentDocker/Executors/Parsers/NetworkInspectResponseParser.cs
@@ -1,0 +1,30 @@
+using Ductus.FluentDocker.Model.Containers;
+using Ductus.FluentDocker.Model.Networks;
+using Newtonsoft.Json;
+
+namespace Ductus.FluentDocker.Executors.Parsers
+{
+  public sealed class NetworkInspectResponseParser : IProcessResponseParser<NetworkConfiguration>
+  {
+    public CommandResponse<NetworkConfiguration> Response { get; private set; }
+
+    public IProcessResponse<NetworkConfiguration> Process(ProcessExecutionResult response)
+    {
+      if (string.IsNullOrEmpty(response.StdOut))
+      {
+        Response = response.ToResponse(false, "No response", new NetworkConfiguration());
+        return this;
+      }
+
+      var resp = JsonConvert.DeserializeObject<NetworkConfiguration[]>(response.StdOut);
+      if (null == resp || 0 == resp.Length)
+      {
+        Response = response.ToResponse(false, "No response", new NetworkConfiguration());
+        return this;
+      }
+
+      Response = response.ToResponse(true, string.Empty, resp[0]);
+      return this;
+    }
+  }
+}

--- a/Ductus.FluentDocker/Executors/Parsers/NetworkLsResponseParser.cs
+++ b/Ductus.FluentDocker/Executors/Parsers/NetworkLsResponseParser.cs
@@ -1,29 +1,66 @@
-﻿using Ductus.FluentDocker.Model.Containers;
+﻿using System;
+using System.Collections.Generic;
+using Ductus.FluentDocker.Model.Containers;
 using Ductus.FluentDocker.Model.Networks;
-using Newtonsoft.Json;
 
 namespace Ductus.FluentDocker.Executors.Parsers
 {
-  public sealed class NetworkLsResponseParser : IProcessResponseParser<NetworkConfiguration>
+  public sealed class NetworkLsResponseParser : IProcessResponseParser<IList<NetworkRow>>
   {
-    public CommandResponse<NetworkConfiguration> Response { get; private set; }
+    public const string Format = "{{.ID}};{{.Name}};{{.Driver}};{{.Scope}};{{.IPv6}};{{.Internal}};{{.CreatedAt}}";
 
-    public IProcessResponse<NetworkConfiguration> Process(ProcessExecutionResult response)
+    public CommandResponse<IList<NetworkRow>> Response { get; private set; }
+
+    public IProcessResponse<IList<NetworkRow>> Process(ProcessExecutionResult response)
     {
+      if (response.ExitCode != 0)
+      {
+        Response = response.ToErrorResponse((IList<NetworkRow>)new List<NetworkRow>());
+        return this;
+      }
+
       if (string.IsNullOrEmpty(response.StdOut))
       {
-        Response = response.ToResponse(false, "No response", new NetworkConfiguration());
+        Response = response.ToResponse(false, "No response", (IList<NetworkRow>)new List<NetworkRow>());
         return this;
       }
 
-      var resp = JsonConvert.DeserializeObject<NetworkConfiguration[]>(response.StdOut);
-      if (null == resp || 0 == resp.Length)
+      var result = new List<NetworkRow>();
+
+      foreach (var row in response.StdOutAsArry)
       {
-        Response = response.ToResponse(false, "No response", new NetworkConfiguration());
-        return this;
+        var items = row.Split(';');
+        if (items.Length < 4)
+          continue;
+
+        var created = DateTime.MinValue;
+        var ipv6 = false;
+        var intern = false;
+
+        if (items.Length > 4)
+          bool.TryParse(items[4], out ipv6);
+        if (items.Length > 5)
+          bool.TryParse(items[5], out intern);
+        if (items.Length > 6)
+        {
+          var split = items[6].Split(" ".ToCharArray());
+          var normalizedStr = $"{split[0]} {split[1]} {split[2].Insert(3, ":")}";
+          DateTime.TryParse(normalizedStr, out created);
+        }
+
+        result.Add(new NetworkRow
+        {
+          Id = items[0],
+          Name = items[1],
+          Driver = items[2],
+          Scope = items[3],
+          IPv6 = ipv6,
+          Internal = intern,
+          Created = created
+        });
       }
 
-      Response = response.ToResponse(true, string.Empty, resp[0]);
+      Response = response.ToResponse(true, string.Empty, (IList<NetworkRow>)result);
       return this;
     }
   }


### PR DESCRIPTION
NetworkLs: Fix parsing of CreatedAt DateTime 
- Move parsing logic out of Network class to a parser
- Fix parser to support negative timezones for CreatedAt date

See #143 