### PR TITLE
Improve GetContainers performance

### DIFF
--- a/Ductus.FluentDocker.Tests/CommandTests/DockerClientCommandTests.cs
+++ b/Ductus.FluentDocker.Tests/CommandTests/DockerClientCommandTests.cs
@@ -200,6 +200,105 @@ namespace Ductus.FluentDocker.Tests.CommandTests
     }
 
     [TestMethod]
+    public void InspectContainersShallSucceed()
+    {
+      // Arrange
+
+      const string image1 = "nginx:1.13.6-alpine";
+      const string image2 = "postgres:9.6-alpine";
+      string id1 = null;
+      string id2 = null;
+
+      try
+      {
+        var cmd = _docker.Run(image1, null, _certificates);
+        IsTrue(cmd.Success);
+        id1 = cmd.Data;
+        IsTrue(!string.IsNullOrWhiteSpace(id1));
+        AreEqual(64, id1.Length);
+
+        cmd = _docker.Create(image2, null);
+        IsTrue(cmd.Success);
+        id2 = cmd.Data;
+        IsTrue(!string.IsNullOrWhiteSpace(id2));
+        AreEqual(64, id2.Length);
+
+
+        // Act
+        var result = _docker.InspectContainers(_certificates);
+
+
+        // Assert
+        IsTrue(result.Success);
+        IsTrue(result.Data.Count > 1);
+        IsNotNull(result.Data.SingleOrDefault(c => c.Id == id1));
+        IsNotNull(result.Data.SingleOrDefault(c => c.Id == id2));
+      }
+      finally
+      {
+        if (null != id1)
+        {
+          _docker.RemoveContainer(id1, true, true, null, _certificates);
+        }
+        if (null != id2)
+        {
+          _docker.RemoveContainer(id2, true, true, null, _certificates);
+        }
+      }
+    }
+
+    [TestMethod]
+    public void InspectContainersByIdsShallSucceed()
+    {
+      // Arrange
+
+      const string image1 = "nginx:1.13.6-alpine";
+      const string image2 = "postgres:9.6-alpine";
+      string id1 = null;
+      string id2 = null;
+
+      try
+      {
+        var cmd = _docker.Run(image1, null, _certificates);
+        IsTrue(cmd.Success);
+        id1 = cmd.Data;
+        IsTrue(!string.IsNullOrWhiteSpace(id1));
+        AreEqual(64, id1.Length);
+
+        cmd = _docker.Create(image2, null);
+        IsTrue(cmd.Success);
+        id2 = cmd.Data;
+        IsTrue(!string.IsNullOrWhiteSpace(id2));
+        AreEqual(64, id2.Length);
+
+
+        // Act
+        var result = _docker.InspectContainers(_certificates, id1, id2);
+
+
+        // Assert
+        IsTrue(result.Success);
+        IsTrue(result.Data[0].Name.Length > 2);
+        IsTrue(result.Data[0].State.Running);
+        AreEqual(image1, result.Data[0].Config.Image);
+        IsTrue(result.Data[1].Name.Length > 2);
+        IsFalse(result.Data[1].State.Running);
+        AreEqual(image2, result.Data[1].Config.Image);
+      }
+      finally
+      {
+        if (null != id1)
+        {
+          _docker.RemoveContainer(id1, true, true, null, _certificates);
+        }
+        if (null != id2)
+        {
+          _docker.RemoveContainer(id2, true, true, null, _certificates);
+        }
+      }
+    }
+
+    [TestMethod]
     public void DiffContainerShallWork()
     {
       string id = null;

--- a/Ductus.FluentDocker.Tests/ServiceTests/ContainerServiceBasicTests.cs
+++ b/Ductus.FluentDocker.Tests/ServiceTests/ContainerServiceBasicTests.cs
@@ -11,6 +11,7 @@ using Ductus.FluentDocker.Services;
 using Ductus.FluentDocker.Services.Extensions;
 using Ductus.FluentDocker.Tests.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 namespace Ductus.FluentDocker.Tests.ServiceTests
 {
@@ -383,6 +384,26 @@ namespace Ductus.FluentDocker.Tests.ServiceTests
         container.Stop();
         container.WaitForStopped();
         Assert.AreEqual(ServiceRunningState.Stopped, container.State);
+      }
+    }
+
+    [TestMethod]
+    public void GetContainersShallWork()
+    {
+      // Arrange
+      using (var container = _host.Create("postgres:9.6-alpine"))
+      using (var container2 = _host.Create("postgres:9.6-alpine"))
+      {
+        container.Start();
+
+        // Act
+        var result = _host.GetContainers(true);
+
+        // Assert
+        Assert.IsNotNull(result.SingleOrDefault(c => c.Id == container.Id
+                                                     && JsonConvert.SerializeObject(c) == JsonConvert.SerializeObject(container)));
+        Assert.IsNotNull(result.SingleOrDefault(c => c.Id == container2.Id
+                                                     && JsonConvert.SerializeObject(c) == JsonConvert.SerializeObject(container2)));
       }
     }
   }

--- a/Ductus.FluentDocker/Commands/Client.cs
+++ b/Ductus.FluentDocker/Commands/Client.cs
@@ -261,6 +261,25 @@ namespace Ductus.FluentDocker.Commands
         $"{host.RenderBaseArgs(certificates)} inspect {id}").Execute();
     }
 
+    public static CommandResponse<IList<Container>> InspectContainers(this DockerUri host,
+      ICertificatePaths certificates = null,
+      params string[] containerIds)
+    {
+      if (containerIds?.Any() != true)
+      {
+        var psResult = host.Ps("--all", certificates);
+        if (!psResult.Success)
+          return new CommandResponse<IList<Container>>(psResult.Success, psResult.Log, psResult.Error);
+
+        containerIds = psResult.Data.ToArray();
+      }
+
+      var dockerBinary = "docker".ResolveBinary();
+      return new ProcessExecutor<ClientInspectContainersResponseParser, IList<Container>>(dockerBinary,
+          $"{host.RenderBaseArgs(certificates)} inspect " + string.Join(" ", containerIds))
+        .Execute();
+    }
+
     public static CommandResponse<ImageConfig> InspectImage(this DockerUri host, string id,
       ICertificatePaths certificates = null)
     {

--- a/Ductus.FluentDocker/Executors/Parsers/ClientInspectContainersResponseParser.cs
+++ b/Ductus.FluentDocker/Executors/Parsers/ClientInspectContainersResponseParser.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+using Ductus.FluentDocker.Model.Containers;
+using Newtonsoft.Json;
+
+namespace Ductus.FluentDocker.Executors.Parsers
+{
+  public sealed class ClientInspectContainersResponseParser : IProcessResponseParser<IList<Container>>
+  {
+    public CommandResponse<IList<Container>> Response { get; private set; }
+
+    public IProcessResponse<IList<Container>> Process(ProcessExecutionResult response)
+    {
+      if (response.ExitCode != 0)
+      {
+        Response = response.ToErrorResponse((IList<Container>)new List<Container>());
+        return this;
+      }
+
+      if (string.IsNullOrEmpty(response.StdOut))
+      {
+        Response = response.ToResponse(false, "Empty response", (IList<Container>)new List<Container>());
+        return this;
+      }
+
+      var containers = JsonConvert.DeserializeObject<Container[]>(response.StdOut);
+      foreach (var c in containers)
+      {
+        c.Name = TrimIfBeginsWithSlash(c.Name);
+      }
+
+      Response = response.ToResponse(true, string.Empty, (IList<Container>)containers.ToList());
+      return this;
+    }
+
+    private static string TrimIfBeginsWithSlash(string name)
+    {
+      if (!string.IsNullOrEmpty(name) && name.StartsWith("/"))
+        return name.Substring(1);
+      return name;
+    }
+  }
+}

--- a/Ductus.FluentDocker/Model/Containers/Container.cs
+++ b/Ductus.FluentDocker/Model/Containers/Container.cs
@@ -2,6 +2,7 @@
 {
   public sealed class Container
   {
+    public string Id { get; set; }
     public string Image { get; set; }
     public string ResolvConfPath { get; set; }
     public string HostnamePath { get; set; }

--- a/Ductus.FluentDocker/Services/Impl/DockerHostService.cs
+++ b/Ductus.FluentDocker/Services/Impl/DockerHostService.cs
@@ -137,15 +137,19 @@ namespace Ductus.FluentDocker.Services.Impl
       if (!string.IsNullOrEmpty(filter))
         options += $" --filter {filter}";
 
-      var result = Host.Ps(options, Certificates);
-      if (!result.Success)
+      var psResult = Host.Ps(options, Certificates);
+      if (!psResult.Success)
         return new List<IContainerService>();
 
-      return (from id in result.Data
-              let config = Host.InspectContainer(id, Certificates)
-              where config.Success && config.Data != null
-              select new DockerContainerService(config.Data.Name, id, Host, config.Data.State.ToServiceState(), Certificates,
-                isWindowsContainer: _isWindowsHost)).Cast<IContainerService>().ToList();
+      var ids = psResult.Data.ToArray();
+
+      var inspectContainersResult = Host.InspectContainers(Certificates, ids);
+      if (!inspectContainersResult.Success)
+        return new List<IContainerService>();
+
+      return inspectContainersResult.Data.Select(c =>
+          new DockerContainerService(c.Name, c.Id, Host, c.State.ToServiceState(), Certificates, isWindowsContainer: _isWindowsHost))
+        .Cast<IContainerService>().ToList();
     }
 
     public IList<IContainerImageService> GetImages(bool all = true, string filter = null)


### PR DESCRIPTION
DockerHostService.GetContainers:
Improve performance by running one inspect command for multiple containers:
docker inspect id1 id2 ... idN

containers cnt | docker cli, ms | GetContainers before, ms | GetContainers after, ms
1 | 95 | 400 | 400
2 | 105 | 545 | 405
8 | 125 | 700 | 440
16 | 160 | 1020 | 460
32 | 210 | 1650 | 520

See #145 