### PR TITLE
Feature pass environment to compose

### DIFF
--- a/Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj
+++ b/Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj
@@ -50,6 +50,12 @@
     <None Update="Resources\Issue\111\server.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Scripts\envtest.bat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Scripts\envtest.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Ductus.FluentDocker.Tests/ExtensionTests/EnironmentExtensionTests.cs
+++ b/Ductus.FluentDocker.Tests/ExtensionTests/EnironmentExtensionTests.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Tests.Compose;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ductus.FluentDocker.Tests.ExtensionTests
+{
+  [TestClass]
+  public class EnironmentExtensionTests
+  {
+    [TestMethod]
+    public void NullStringShallGiveNullReturnInExtract()
+    {
+      var t = EnvironmentExtensions.Extract(null);
+      Assert.IsNull(t);
+    }
+    [TestMethod]
+    public void EmptyStringShallGiveNullReturnInExtract()
+    {
+      var t = "".Extract();
+      Assert.IsNull(t);
+    }
+    [TestMethod]
+    public void OnlyWhitespaceStringShallGiveNullReturnInExtract()
+    {
+      var t = "   ".Extract();
+      Assert.IsNull(t);
+    }
+    [TestMethod]
+    public void SingleNameNotEqualSignGivesStringShallGiveNameAnEmptyStringReturnInExtract()
+    {
+      var t = "CUSTOM_ENV".Extract();
+      Assert.AreEqual("CUSTOM_ENV", t.Item1);
+      Assert.IsTrue(t.Item2 == string.Empty);
+    }
+    [TestMethod]
+    public void SingleNameWithEqualSignGivesStringShallGiveNameAnEmptyStringReturnInExtract()
+    {
+      var t = "CUSTOM_ENV=".Extract();
+      Assert.AreEqual("CUSTOM_ENV", t.Item1);
+      Assert.IsTrue(t.Item2 == string.Empty);
+    }
+    [TestMethod]
+    public void NameValueShallReturnNameAndValue()
+    {
+      var t = "CUSTOM_ENV=custom value".Extract();
+      Assert.AreEqual("CUSTOM_ENV", t.Item1);
+      Assert.AreEqual("custom value", t.Item2);
+    }
+    [TestMethod]
+    public void ItShallBePossibleToHaveEqualSignsInTheValue()
+    {
+      var t = "CUSTOM_ENV=custom value with = sign shall be possible".Extract();
+      Assert.AreEqual("CUSTOM_ENV", t.Item1);
+      Assert.AreEqual("custom value with = sign shall be possible", t.Item2);
+    }
+  }
+}

--- a/Ductus.FluentDocker.Tests/ProcessTests/ProcessEnvironmentTest.cs
+++ b/Ductus.FluentDocker.Tests/ProcessTests/ProcessEnvironmentTest.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.IO;
+using Ductus.FluentDocker.Common;
+using Ductus.FluentDocker.Executors;
+using Ductus.FluentDocker.Executors.Parsers;
+using Ductus.FluentDocker.Model.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ductus.FluentDocker.Tests.ProcessTests
+{
+  [TestClass]
+
+  public class ProcessEnvironmentTest
+  {
+    [TestMethod]
+    public void ProcessShallPassCustomEnvironment()
+    {
+      var cmd = "Resources/Scripts/envtest." + (FdOs.IsWindows() ? "bat" : "sh");
+      var file = Path.Combine(Directory.GetCurrentDirectory(), (TemplateString)cmd);
+
+      var executor = new ProcessExecutor<StringListResponseParser, IList<string>>(file, string.Empty);
+      executor.Env["FD_CUSTOM_ENV"] = "My test environment variable";
+
+      var result = executor.Execute();
+      Assert.AreEqual("My test environment variable", result.Data[FdOs.IsWindows() ? 1 : 0]);
+    }
+  }
+}

--- a/Ductus.FluentDocker.Tests/Resources/Scripts/envtest.bat
+++ b/Ductus.FluentDocker.Tests/Resources/Scripts/envtest.bat
@@ -1,0 +1,1 @@
+echo %FD_CUSTOM_ENV%

--- a/Ductus.FluentDocker.Tests/Resources/Scripts/envtest.sh
+++ b/Ductus.FluentDocker.Tests/Resources/Scripts/envtest.sh
@@ -1,0 +1,1 @@
+echo $FD_CUSTOM_ENV

--- a/Ductus.FluentDocker/Builders/CompositeBuilder.cs
+++ b/Ductus.FluentDocker/Builders/CompositeBuilder.cs
@@ -260,6 +260,34 @@ namespace Ductus.FluentDocker.Builders
     }
 
     /// <summary>
+    /// Sets environment variables when executing docker
+    /// compose. Those may be used in a docker-compose file
+    /// to pass dynamic information such as image labels etc.
+    /// </summary>
+    /// <param name="nameValue">An array of name=value string. It is possilbe to have equal sign
+    /// in the value area since it will use the first encountered equal sign as the enviroment variable
+    /// name and the value.</param>
+    /// <returns>Itself for fluent access.</returns>
+    public CompositeBuilder WithEnvironment(params string[] nameValue)
+    {
+      if (null == nameValue || 0 == nameValue.Length)
+      {
+        return this;
+      }
+
+      foreach(var nv in nameValue)
+      {
+        var env = nv.Extract();
+        if (null == env || string.IsNullOrWhiteSpace(env.Item1))
+          continue;
+        _config.EnvironmentNameValue.Add(env.Item1, env.Item2 ?? string.Empty);
+      }
+
+      return this;
+    }
+
+
+    /// <summary>
     /// Kept for backward compatibility, will be removed in 3.0.0.
     /// </summary>
     /// <returns>Itself for fluent access.</returns>

--- a/Ductus.FluentDocker/Builders/CompositeBuilder.cs
+++ b/Ductus.FluentDocker/Builders/CompositeBuilder.cs
@@ -275,7 +275,7 @@ namespace Ductus.FluentDocker.Builders
         return this;
       }
 
-      foreach(var nv in nameValue)
+      foreach (var nv in nameValue)
       {
         var env = nv.Extract();
         if (null == env || string.IsNullOrWhiteSpace(env.Item1))

--- a/Ductus.FluentDocker/Commands/Compose.cs
+++ b/Ductus.FluentDocker/Commands/Compose.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Ductus.FluentDocker.Executors;
@@ -15,7 +15,9 @@ namespace Ductus.FluentDocker.Commands
     public static CommandResponse<IList<string>> ComposeBuild(this DockerUri host,
       string altProjectName = null,
       bool forceRm = false, bool dontUseCache = false,
-      bool alwaysPull = false, string[] services = null /*all*/, ICertificatePaths certificates = null,
+      bool alwaysPull = false, string[] services = null /*all*/,
+      IDictionary<string, string> env = null,
+      ICertificatePaths certificates = null,
       params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
@@ -46,7 +48,7 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} build {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} build {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeCreate(this DockerUri host,
@@ -54,6 +56,7 @@ namespace Ductus.FluentDocker.Commands
       bool forceRecreate = false, bool noRecreate = false, bool dontBuild = false,
       bool buildBeforeCreate = false,
       string[] services = null /*all*/,
+      IDictionary<string, string> env = null,
       ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
@@ -86,11 +89,13 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} create {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} create {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeStart(this DockerUri host, string altProjectName = null,
-      string[] services = null /*all*/, ICertificatePaths certificates = null, params string[] composeFile)
+      string[] services = null /*all*/,
+      IDictionary<string, string> env = null,
+      ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
       var args = $"{host.RenderBaseArgs(certificates)}";
@@ -110,11 +115,12 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} start -d {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} start -d {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeKill(this DockerUri host, string altProjectName = null,
       UnixSignal signal = UnixSignal.SIGKILL, string[] services = null /*all*/,
+      IDictionary<string, string> env = null,
       ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
@@ -138,11 +144,12 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} kill {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} kill {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeStop(this DockerUri host, string altProjectName = null,
       TimeSpan? timeout = null, string[] services = null /*all*/,
+      IDictionary<string, string> env = null,
       ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
@@ -166,11 +173,13 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} stop {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} stop {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposePause(this DockerUri host, string altProjectName = null,
-      string[] services = null /*all*/, ICertificatePaths certificates = null, params string[] composeFile)
+      string[] services = null /*all*/,
+      IDictionary<string, string> env = null,
+      ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
       var args = $"{host.RenderBaseArgs(certificates)}";
@@ -190,11 +199,13 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} pause {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} pause {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeUnPause(this DockerUri host, string altProjectName = null,
-      string[] services = null /*all*/, ICertificatePaths certificates = null, params string[] composeFile)
+      string[] services = null /*all*/,
+      IDictionary<string, string> env = null,
+      ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
       var args = $"{host.RenderBaseArgs(certificates)}";
@@ -214,13 +225,15 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} unpause {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} unpause {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeScale(this DockerUri host, string altProjectName = null,
       TimeSpan? shutdownTimeout = null,
-      string[] serviceEqNumber = null /*all*/, ICertificatePaths certificates = null
-      , params string[] composeFile)
+      string[] serviceEqNumber = null /*all*/,
+      IDictionary<string, string> env = null,
+      ICertificatePaths certificates = null,
+      params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
       var args = $"{host.RenderBaseArgs(certificates)}";
@@ -244,12 +257,14 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} scale {options} {services}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} scale {options} {services}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeVersion(this DockerUri host, string altProjectName = null,
-      bool shortVersion = false, ICertificatePaths certificates = null
-      , params string[] composeFile)
+      bool shortVersion = false,
+      IDictionary<string, string> env = null,
+      ICertificatePaths certificates = null,
+      params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
       var args = $"{host.RenderBaseArgs(certificates)}";
@@ -268,11 +283,13 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} version {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} version {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeRestart(this DockerUri host, string altProjectName = null,
-      string[] composeFile = null, TimeSpan? timeout = null, ICertificatePaths certificates = null,
+      string[] composeFile = null, TimeSpan? timeout = null,
+      IDictionary<string, string> env = null,
+      ICertificatePaths certificates = null,
       params string[] containerId)
     {
       var cwd = WorkingDirectory(composeFile);
@@ -297,12 +314,13 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} restart {options} {ids}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} restart {options} {ids}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposePort(this DockerUri host, string containerId,
       string privatePortAndProto = null,
       string altProjectName = null,
+      IDictionary<string, string> env = null,
       ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
@@ -321,12 +339,14 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} port {containerId} {privatePortAndProto}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} port {containerId} {privatePortAndProto}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeConfig(this DockerUri host, string altProjectName = null,
       bool quiet = true,
-      bool outputServices = false, ICertificatePaths certificates = null, params string[] composeFile)
+      bool outputServices = false,
+      IDictionary<string, string> env = null,
+      ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
       var args = $"{host.RenderBaseArgs(certificates)}";
@@ -349,12 +369,14 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} config {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} config {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeDown(this DockerUri host, string altProjectName = null,
       ImageRemovalOption removeImagesFrom = ImageRemovalOption.None,
-      bool removeVolumes = false, bool removeOrphanContainers = false, ICertificatePaths certificates = null,
+      bool removeVolumes = false, bool removeOrphanContainers = false,
+      IDictionary<string, string> env = null,
+      ICertificatePaths certificates = null,
       params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
@@ -381,7 +403,7 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} down {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} down {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeUp(this DockerUri host,
@@ -392,6 +414,7 @@ namespace Ductus.FluentDocker.Commands
       bool useColor = false,
       bool noStart = false,
       string[] services = null /*all*/,
+      IDictionary<string, string> env = null,
       ICertificatePaths certificates = null, params string[] composeFile)
     {
       if (forceRecreate && noRecreate)
@@ -440,13 +463,15 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} up {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} up {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposeRm(this DockerUri host, string altProjectName = null,
       bool force = false,
       bool removeVolumes = false,
-      string[] services = null /*all*/, ICertificatePaths certificates = null, params string[] composeFile)
+      string[] services = null /*all*/,
+      IDictionary<string, string> env = null,
+      ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
       var args = $"{host.RenderBaseArgs(certificates)}";
@@ -474,11 +499,12 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} rm {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} rm {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposePs(this DockerUri host, string altProjectName = null,
       string[] services = null,
+      IDictionary<string, string> env = null,
       ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
@@ -499,12 +525,13 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} ps -q {options}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} ps -q {options}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     public static CommandResponse<IList<string>> ComposePull(this DockerUri host, string image,
       string altProjectName = null,
       bool downloadAllTagged = false, bool skipImageverficiation = false,
+      IDictionary<string, string> env = null,
       ICertificatePaths certificates = null, params string[] composeFile)
     {
       var cwd = WorkingDirectory(composeFile);
@@ -528,7 +555,7 @@ namespace Ductus.FluentDocker.Commands
       return
         new ProcessExecutor<StringListResponseParser, IList<string>>(
           "docker-compose".ResolveBinary(),
-          $"{args} pull {options} {image}", cwd.NeedCwd ? cwd.Cwd : null).Execute();
+          $"{args} pull {options} {image}", cwd.NeedCwd ? cwd.Cwd : null).ExecutionEnvironment(env).Execute();
     }
 
     private static WorkingDirectoryInfo WorkingDirectory(params string[] composeFile)

--- a/Ductus.FluentDocker/Executors/ProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/ProcessExecutor.cs
@@ -45,7 +45,7 @@ namespace Ductus.FluentDocker.Executors
 
       if (0 != Env.Count)
       {
-        foreach(var key in Env.Keys)
+        foreach (var key in Env.Keys)
         {
 #if COREFX
           startInfo.Environment[key] = Env[key];

--- a/Ductus.FluentDocker/Executors/ProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/ProcessExecutor.cs
@@ -55,22 +55,25 @@ namespace Ductus.FluentDocker.Executors
 
       Logger.Log($"cmd: {_command} - arg: {_arguments}");
 
-      using (var process = new Process {StartInfo = startInfo})
+      using (var process = new Process { StartInfo = startInfo })
       {
         var output = new StringBuilder();
         var err = new StringBuilder();
 
         process.OutputDataReceived += (sender, args) =>
         {
-          if (!string.IsNullOrEmpty(args.Data)) output.AppendLine(args.Data);
+          if (!string.IsNullOrEmpty(args.Data))
+            output.AppendLine(args.Data);
         };
 
         process.ErrorDataReceived += (sender, args) =>
         {
-          if (!string.IsNullOrEmpty(args.Data)) err.AppendLine(args.Data);
+          if (!string.IsNullOrEmpty(args.Data))
+            err.AppendLine(args.Data);
         };
 
-        if (!process.Start()) throw new FluentDockerException($"Could not start process {_command}");
+        if (!process.Start())
+          throw new FluentDockerException($"Could not start process {_command}");
 
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();

--- a/Ductus.FluentDocker/Executors/ProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/ProcessExecutor.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using Ductus.FluentDocker.Common;
 using Ductus.FluentDocker.Extensions;
@@ -27,6 +28,8 @@ namespace Ductus.FluentDocker.Executors
       _arguments = arguments;
     }
 
+    public IDictionary<string, string> Env { get; } = new Dictionary<string, string>();
+
     public CommandResponse<TE> Execute()
     {
       var startInfo = new ProcessStartInfo
@@ -40,6 +43,17 @@ namespace Ductus.FluentDocker.Executors
         WorkingDirectory = _workingdir
       };
 
+      if (0 != Env.Count)
+      {
+        foreach(var key in Env.Keys)
+        {
+#if COREFX
+          startInfo.Environment[key] = Env[key];
+#else
+         startInfo.EnvironmentVariables[key] = Env[key]; 
+#endif
+        }
+      }
 
       Logger.Log($"cmd: {_command} - arg: {_arguments}");
 

--- a/Ductus.FluentDocker/Executors/ProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/ProcessExecutor.cs
@@ -50,7 +50,7 @@ namespace Ductus.FluentDocker.Executors
 #if COREFX
           startInfo.Environment[key] = Env[key];
 #else
-         startInfo.EnvironmentVariables[key] = Env[key]; 
+          startInfo.EnvironmentVariables[key] = Env[key]; 
 #endif
         }
       }

--- a/Ductus.FluentDocker/Executors/ProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/ProcessExecutor.cs
@@ -9,8 +9,8 @@ namespace Ductus.FluentDocker.Executors
 {
   public sealed class ProcessExecutor<T, TE> where T : IProcessResponseParser<TE>, IProcessResponse<TE>, new()
   {
-    private readonly string _command;
     private readonly string _arguments;
+    private readonly string _command;
     private readonly string _workingdir;
 
     public ProcessExecutor(string command, string arguments, string workingdir = null)
@@ -44,44 +44,33 @@ namespace Ductus.FluentDocker.Executors
       };
 
       if (0 != Env.Count)
-      {
         foreach (var key in Env.Keys)
         {
 #if COREFX
           startInfo.Environment[key] = Env[key];
 #else
-          startInfo.EnvironmentVariables[key] = Env[key]; 
+          startInfo.EnvironmentVariables[key] = Env[key];
 #endif
         }
-      }
 
       Logger.Log($"cmd: {_command} - arg: {_arguments}");
 
-      using (var process = new Process { StartInfo = startInfo })
+      using (var process = new Process {StartInfo = startInfo})
       {
         var output = new StringBuilder();
         var err = new StringBuilder();
 
         process.OutputDataReceived += (sender, args) =>
         {
-          if (!string.IsNullOrEmpty(args.Data))
-          {
-            output.AppendLine(args.Data);
-          }
+          if (!string.IsNullOrEmpty(args.Data)) output.AppendLine(args.Data);
         };
 
         process.ErrorDataReceived += (sender, args) =>
         {
-          if (!string.IsNullOrEmpty(args.Data))
-          {
-            err.AppendLine(args.Data);
-          }
+          if (!string.IsNullOrEmpty(args.Data)) err.AppendLine(args.Data);
         };
 
-        if (!process.Start())
-        {
-          throw new FluentDockerException($"Could not start process {_command}");
-        }
+        if (!process.Start()) throw new FluentDockerException($"Could not start process {_command}");
 
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();

--- a/Ductus.FluentDocker/Extensions/EnvironmentExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/EnvironmentExtensions.cs
@@ -15,7 +15,7 @@ namespace Ductus.FluentDocker.Extensions
       if (-1 == idx)
         return new Tuple<string, string>(envExpression.Trim(), string.Empty);
 
-      if (idx == envExpression.Length -1)
+      if (idx == envExpression.Length - 1)
         return new Tuple<string, string>(envExpression.Substring(0, idx).Trim(), string.Empty);
 
       return new Tuple<string, string>(envExpression.Substring(0, idx).Trim(), envExpression.Substring(idx + 1, envExpression.Length - idx - 1));
@@ -26,7 +26,7 @@ namespace Ductus.FluentDocker.Extensions
       if (null == env || 0 == env.Count)
         return executor;
 
-      foreach(var key in env.Keys)
+      foreach (var key in env.Keys)
       {
         executor.Env[key] = env[key];
       }

--- a/Ductus.FluentDocker/Extensions/EnvironmentExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/EnvironmentExtensions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Ductus.FluentDocker.Executors;
+
+namespace Ductus.FluentDocker.Extensions
+{
+  public static class EnvironmentExtensions
+  {
+    public static Tuple<string, string> Extract(this string envExpression)
+    {
+      if (string.IsNullOrWhiteSpace(envExpression))
+        return null;
+
+      var idx = envExpression.IndexOf('=');
+      if (-1 == idx)
+        return new Tuple<string, string>(envExpression.Trim(), string.Empty);
+
+      if (idx == envExpression.Length -1)
+        return new Tuple<string, string>(envExpression.Substring(0, idx).Trim(), string.Empty);
+
+      return new Tuple<string, string>(envExpression.Substring(0, idx).Trim(), envExpression.Substring(idx + 1, envExpression.Length - idx - 1));
+    }
+
+    public static ProcessExecutor<T, TE> ExecutionEnvironment<T, TE>(this ProcessExecutor<T, TE> executor, IDictionary<string, string> env) where T : IProcessResponseParser<TE>, IProcessResponse<TE>, new()
+    {
+      if (null == env || 0 == env.Count)
+        return executor;
+
+      foreach(var key in env.Keys)
+      {
+        executor.Env[key] = env[key];
+      }
+
+      return executor;
+    }
+  }
+}

--- a/Ductus.FluentDocker/Model/Compose/DockerComposeConfig.cs
+++ b/Ductus.FluentDocker/Model/Compose/DockerComposeConfig.cs
@@ -23,7 +23,7 @@ namespace Ductus.FluentDocker.Model.Compose
     public string[] Services { get; set; }
     public bool StopOnDispose { get; set; } = true;
     public bool KeepContainers { get; set; }
-    public IDictionary<string,string> EnvironmentNameValue { get; set; } = new Dictionary<string, string>();
+    public IDictionary<string, string> EnvironmentNameValue { get; set; } = new Dictionary<string, string>();
 
     public IDictionary<string, ContainerSpecificConfig> ContainerConfiguration { get; } =
       new Dictionary<string, ContainerSpecificConfig>();

--- a/Ductus.FluentDocker/Model/Compose/DockerComposeConfig.cs
+++ b/Ductus.FluentDocker/Model/Compose/DockerComposeConfig.cs
@@ -23,6 +23,7 @@ namespace Ductus.FluentDocker.Model.Compose
     public string[] Services { get; set; }
     public bool StopOnDispose { get; set; } = true;
     public bool KeepContainers { get; set; }
+    public IDictionary<string,string> EnvironmentNameValue { get; set; } = new Dictionary<string, string>();
 
     public IDictionary<string, ContainerSpecificConfig> ContainerConfiguration { get; } =
       new Dictionary<string, ContainerSpecificConfig>();

--- a/Ductus.FluentDocker/Services/Impl/DockerComposeCompositeService.cs
+++ b/Ductus.FluentDocker/Services/Impl/DockerComposeCompositeService.cs
@@ -41,7 +41,7 @@ namespace Ductus.FluentDocker.Services.Impl
         var host = Hosts.First();
 
         var result = host.Host.ComposeDown(_config.AlternativeServiceName, _config.ImageRemoval,
-          !_config.KeepVolumes, _config.RemoveOrphans, host.Certificates,
+          !_config.KeepVolumes, _config.RemoveOrphans, _config.EnvironmentNameValue, host.Certificates,
           _config.ComposeFilePath.ToArray());
 
         if (!result.Success)
@@ -117,7 +117,7 @@ namespace Ductus.FluentDocker.Services.Impl
       var host = Hosts.First();
       if (State == ServiceRunningState.Paused)
       {
-        var upr = host.Host.ComposeUnPause(_config.AlternativeServiceName, _config.Services,
+        var upr = host.Host.ComposeUnPause(_config.AlternativeServiceName, _config.Services, _config.EnvironmentNameValue,
           host.Certificates, _config.ComposeFilePath.ToArray());
 
         if (!upr.Success)
@@ -135,6 +135,7 @@ namespace Ductus.FluentDocker.Services.Impl
         _config.UseColor,
         false,
         _config.Services,
+        _config.EnvironmentNameValue,
         host.Certificates, _config.ComposeFilePath.ToArray());
 
       if (!result.Success)
@@ -144,7 +145,7 @@ namespace Ductus.FluentDocker.Services.Impl
           $"Could not start composite service {_config.ComposeFilePath} - result: {result}");
       }
 
-      var containers = host.Host.ComposePs(_config.AlternativeServiceName, _config.Services,
+      var containers = host.Host.ComposePs(_config.AlternativeServiceName, _config.Services, _config.EnvironmentNameValue,
         host.Certificates, _config.ComposeFilePath.ToArray());
 
       if (!containers.Success)
@@ -170,7 +171,7 @@ namespace Ductus.FluentDocker.Services.Impl
         return;
 
       var host = Hosts.First();
-      var pause = host.Host.ComposePause(_config.AlternativeServiceName, _config.Services,
+      var pause = host.Host.ComposePause(_config.AlternativeServiceName, _config.Services, _config.EnvironmentNameValue,
         host.Certificates, _config.ComposeFilePath.ToArray());
 
       if (!pause.Success)
@@ -196,7 +197,7 @@ namespace Ductus.FluentDocker.Services.Impl
       var host = Hosts.First();
 
       var result = host.Host.ComposeStop(_config.AlternativeServiceName, TimeSpan.FromSeconds(30),
-        _config.Services, host.Certificates, _config.ComposeFilePath.ToArray());
+        _config.Services, _config.EnvironmentNameValue, host.Certificates, _config.ComposeFilePath.ToArray());
 
       if (!result.Success)
       {
@@ -213,7 +214,7 @@ namespace Ductus.FluentDocker.Services.Impl
       var host = Hosts.First();
 
       var result = host.Host.ComposeRm(_config.AlternativeServiceName, force,
-        !_config.KeepVolumes, _config.Services, host.Certificates, _config.ComposeFilePath.ToArray());
+        !_config.KeepVolumes, _config.Services, _config.EnvironmentNameValue, host.Certificates, _config.ComposeFilePath.ToArray());
 
       if (!result.Success)
       {


### PR DESCRIPTION
This relates to Issue #147 where it is possible to pass environment to all compose commands and therefore it may be possible to use those environment variables in the docker-compose file. Since each invocation is shielded in the `ProcessExecutor` the environment variables are local for each invocation.

Given:
```yaml
build:
  context: .
  labels:
    - "com.example.description=${DESCRIPTION}"
    - "${CUSTOM_NAME}=${CUSTOM_VALUE}"
```
Set environment for the Compose in the _FluentAPI_:
```cs
Fd.UseContainer()
	.WithEnvironment()	
	.UseCompose()
	.FromFile(ComposeFilePaths)
	.ServiceName(ComposeProjectName)
	.WithEnvironment(
		$"DESCRIPTION={description}",
		$"CUSTOM_NAME={buildname}",
		$"CUSTOM_VALUE={buildtag}")	
	.RemoveOrphans()	
	.WaitForPort(ComposeProjectName, $"{PrivateServicePort.Port}/tcp", ServiceWaitTime)
	.Build();
```

Where `description`, `buildname` and `buildtag` is in this example three strings.