### PR TITLE
Use .NET Trace for logging purposes.

### DIFF
--- a/Ductus.FluentDocker.Tests/Common/LoggerTests.cs
+++ b/Ductus.FluentDocker.Tests/Common/LoggerTests.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Ductus.FluentDocker.Common;
+using Ductus.FluentDocker.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ductus.FluentDocker.Tests.Common
+{
+  [TestClass]
+  public class LoggerTests
+  {
+    [TestMethod]
+    public void ShouldNotLogToTraceListenerWhenLoggerIsDisabled()
+    {
+      Logging.Disabled();
+
+      // Arrange
+      var messages = new List<string>
+      {
+        "message 1",
+        "message 2",
+        "message 3",
+      };
+
+      var actualTraceMessages = new List<string>();
+
+      Trace.Listeners.Add(new UnitTestingTraceListener
+      {
+        OnWriteLine = actualTraceMessages.Add
+      });
+
+      // Act
+      messages.ForEach(Logger.Log);
+      Trace.Flush();
+
+      // Assert
+      Assert.IsFalse(actualTraceMessages.Any());
+    }
+
+    [TestMethod]
+    public void ShouldLogToTraceListenerWhenLoggerIsEnabled()
+    {
+      Logging.Enabled();
+
+      // Arrange
+      var messages = new List<string>
+      {
+        "message 1",
+        "message 2",
+        "message 3",
+      };
+
+      var expectedTraceMessages = messages
+                                    .Select(message => $"Ductus.FluentDocker: {message}")
+                                    .ToList();
+
+      var actualTraceMessages = new List<string>();
+
+      Trace.Listeners.Add(new UnitTestingTraceListener
+      {
+        OnWriteLine = actualTraceMessages.Add
+      });
+
+      // Act
+      messages.ForEach(Logger.Log);
+      Trace.Flush();
+
+      // Assert
+      CollectionAssert.AreEqual(expectedTraceMessages, actualTraceMessages);
+    }
+  }
+}

--- a/Ductus.FluentDocker.Tests/Common/UnitTestingTraceListener.cs
+++ b/Ductus.FluentDocker.Tests/Common/UnitTestingTraceListener.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Diagnostics;
+
+namespace Ductus.FluentDocker.Tests.Common
+{
+  internal sealed class UnitTestingTraceListener : TraceListener
+  {
+    private static readonly Action<string> doNothing = (x) => { /* Do nothing */ };
+    public Action<string> OnWrite { get; set; } = doNothing;
+    public Action<string> OnWriteLine { get; set; } = doNothing;
+    public override string Name { get; set; } = "Unit Testing Trace Listener";
+
+    public override void Write(string message) => OnWrite(message);
+
+    public override void WriteLine(string message) => OnWriteLine(message);
+  }
+}

--- a/Ductus.FluentDocker/Common/Logger.cs
+++ b/Ductus.FluentDocker/Common/Logger.cs
@@ -1,11 +1,4 @@
-﻿#if NETSTANDARD2_1
-using Microsoft.Extensions.Logging.Debug;
-#endif
-#if COREFX
-using System;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-#endif
+using System.Diagnostics;
 
 namespace Ductus.FluentDocker.Common
 {
@@ -18,25 +11,7 @@ namespace Ductus.FluentDocker.Common
       if (!Enabled)
         return;
 
-#if COREFX
-      InternalLogger.Value.LogTrace(message);
+      Trace.WriteLine(message, Constants.DebugCategory);
     }
-
-
-    private static readonly Lazy<ILogger> InternalLogger
-      = new Lazy<ILogger>(() =>
-      {
-        var factory = new ServiceCollection().AddLogging().BuildServiceProvider().GetRequiredService<ILoggerFactory>();
-#if NETSTANDARD2_1
-        factory.AddProvider(new DebugLoggerProvider());
-#else
-        factory.AddDebug();
-#endif
-        return factory.CreateLogger(Constants.DebugCategory);
-      });
-#else
-      System.Diagnostics.Debugger.Log((int)System.Diagnostics.TraceLevel.Verbose, Constants.DebugCategory, message);
-    }
-#endif
   }
 }

--- a/Ductus.FluentDocker/Ductus.FluentDocker.csproj
+++ b/Ductus.FluentDocker/Ductus.FluentDocker.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />


### PR DESCRIPTION
#### Context

The following pull request moves the logging capabilities of the library to the `Trace` implementation in dotnet.

The previous code had issues regarding the configuration which were expressed on #170. 

With this new implementation the logs generated by the library will now be available to the active `Trace.Listeners` which can then be routed to the logging framework of choice. For example, like [this](https://stackoverflow.com/questions/54537694/how-i-can-transfer-all-messages-from-system-diagnostics-trace-to-ilogger).

#### FAQ

**Why `Trace.WriteLine` and not `Debug.WriteLine`?**
In most implementations both will redirect to the `Trace.Listeners` but on `netcoreapp2.0` the following error happens https://github.com/dotnet/runtime/issues/26781

Checklist:
- [x] Develop unit tests
- [ ] Update documentation