### PR TITLE
Add alias on UseNetwork()

### DIFF
--- a/Ductus.FluentDocker/Model/Builders/ContainerBuilderConfig.cs
+++ b/Ductus.FluentDocker/Model/Builders/ContainerBuilderConfig.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Ductus.FluentDocker.Model.Common;
 using Ductus.FluentDocker.Model.Compose;
 using Ductus.FluentDocker.Model.Containers;
+using Ductus.FluentDocker.Model.Networks;
 using Ductus.FluentDocker.Services;
 
 namespace Ductus.FluentDocker.Model.Builders
@@ -34,8 +35,8 @@ namespace Ductus.FluentDocker.Model.Builders
     public Tuple<TemplateString /*host*/, bool /*explode*/,
       Func<IContainerService, bool> /*condition*/> ExportOnDispose
     { get; set; }
-    public List<INetworkService> Networks { get; set; }
-    public List<string> NetworkNames { get; set; }
+    public List<NetworkAttachConfiguration> Networks { get; set; }
+    public List<NetworkNameAttachConfiguration> NetworkNames { get; set; }
     public List<string> ExecuteOnRunningArguments { get; set; }
     public List<string> ExecuteOnDisposingArguments { get; set; }
   }

--- a/Ductus.FluentDocker/Model/Containers/ContainerCreateParams.cs
+++ b/Ductus.FluentDocker/Model/Containers/ContainerCreateParams.cs
@@ -678,6 +678,15 @@ namespace Ductus.FluentDocker.Model.Containers
     public string Network { get; set; }
 
     /// <summary>
+    ///   The alias to use when connectin to the network
+    ///   specified by <see cref="Network"/>
+    /// </summary>
+    /// <remarks>
+    ///   --network-alias
+    /// </remarks>
+    public string NetworkAlias { get; set; }
+
+    /// <summary>
     ///   Container IPv4 address (e.g. 172.30.100.104).
     /// </summary>
     /// <remarks>
@@ -899,6 +908,7 @@ namespace Ductus.FluentDocker.Model.Containers
       sb.OptionIfExists("-l ", Labels);
       sb.OptionIfExists("--group-add=", Groups);
       sb.OptionIfExists("--network ", Network);
+      sb.OptionIfExists("--network-alias ", NetworkAlias);
       sb.OptionIfExists("--ip ", Ipv4);
       sb.OptionIfExists("--ip6 ", Ipv6);
 
@@ -959,7 +969,6 @@ namespace Ductus.FluentDocker.Model.Containers
   --log-opt=[]                    Log driver options
   --mac-address                   Container MAC address (e.g. 92:d0:c6:0a:29:33)
   --net=default                   Connect a container to a network
-  --net-alias=[]                  Add network-scoped alias for the container
   --oom-score-adj                 Tune host's OOM preferences (-1000 to 1000)
   --read-only                     Mount the container's root filesystem as read only
   --security-opt=[]               Security Options

--- a/Ductus.FluentDocker/Model/Networks/NetworkAttachConfiguration.cs
+++ b/Ductus.FluentDocker/Model/Networks/NetworkAttachConfiguration.cs
@@ -1,0 +1,10 @@
+using Ductus.FluentDocker.Services;
+
+namespace Ductus.FluentDocker.Model.Networks
+{
+  public sealed class NetworkAttachConfiguration
+  {
+    public string Alias { get; set; }
+    public INetworkService Network { get; set; }
+  }
+}

--- a/Ductus.FluentDocker/Model/Networks/NetworkNameAttachConfiguration.cs
+++ b/Ductus.FluentDocker/Model/Networks/NetworkNameAttachConfiguration.cs
@@ -1,0 +1,10 @@
+using Ductus.FluentDocker.Services;
+
+namespace Ductus.FluentDocker.Model.Networks
+{
+  public sealed class NetworkNameAttachConfiguration
+  {
+    public string Alias { get; set; }
+    public string NetworkName { get; set; }
+  }
+}

--- a/Ductus.FluentDocker/Services/INetworkService.cs
+++ b/Ductus.FluentDocker/Services/INetworkService.cs
@@ -1,4 +1,4 @@
-﻿using Ductus.FluentDocker.Model.Common;
+using Ductus.FluentDocker.Model.Common;
 using Ductus.FluentDocker.Model.Containers;
 using Ductus.FluentDocker.Model.Networks;
 
@@ -11,8 +11,8 @@ namespace Ductus.FluentDocker.Services
     ICertificatePaths Certificates { get; }
     NetworkConfiguration GetConfiguration(bool fresh = false);
 
-    INetworkService Attach(IContainerService container, bool detatchOnDisposeNetwork);
-    INetworkService Attach(string containerId, bool detatchOnDisposeNetwork);
+    INetworkService Attach(IContainerService container, bool detatchOnDisposeNetwork, string alias = null);
+    INetworkService Attach(string containerId, bool detatchOnDisposeNetwork, string alias = null);
     INetworkService Detatch(IContainerService container, bool force = false);
     INetworkService Detatch(string containerId, bool force = false);
   }

--- a/Ductus.FluentDocker/Services/Impl/DockerNetworkService.cs
+++ b/Ductus.FluentDocker/Services/Impl/DockerNetworkService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Ductus.FluentDocker.Commands;
 using Ductus.FluentDocker.Common;
 using Ductus.FluentDocker.Model.Common;
@@ -39,17 +40,17 @@ namespace Ductus.FluentDocker.Services.Impl
       return _config = result.Data;
     }
 
-    public INetworkService Attach(IContainerService container, bool detatchOnDisposeNetwork)
+    public INetworkService Attach(IContainerService container, bool detatchOnDisposeNetwork, string alias = null)
     {
-      return Attach(container.Id, detatchOnDisposeNetwork);
+      return Attach(container.Id, detatchOnDisposeNetwork, alias: alias);
     }
 
-    public INetworkService Attach(string containerId, bool detatchOnDisposeNetwork)
+    public INetworkService Attach(string containerId, bool detatchOnDisposeNetwork, string alias = null)
     {
       if (detatchOnDisposeNetwork)
         _detatchOnDispose.Add(containerId);
 
-      DockerHost.NetworkConnect(containerId, Id, certificates: Certificates);
+      DockerHost.NetworkConnect(containerId, Id, certificates: Certificates, alias: alias == null ? null : new string[] { alias } );
       return this;
     }
 


### PR DESCRIPTION
# Changes
I ran into the issue that I wanted to attach containers to pre-created networks via `UseNetwork(params string[] network)` and `UseNetwork(params INetworkService[] network)` but there is no way to pass an alias.

`DockerHost.NetworkAttach` already has the ability to take in the alias to use so I added the ability to pass an alias via `UseNetwork()`. The alias will be used for every network passed in the params array. Because the first network is added via the container create parameters I added `--network-alias` to `ContainerCreateParams`.

To keep the API as backward compatible as possible I added `alias` as an optional parameter where it was added. The only change to the external API is in the class `ContainerBuilderConfig` which has the types of `Networks` and `NetworkNames` changed.

# Tests
I was trying to figure out where I should be adding tests to make sure this is working but I am not totally following the testing structure. Some pointers in the right direction would be really helpful.