### PR TITLE
Fix error messages docker-compose files

### DIFF
--- a/Ductus.FluentDocker.Tests/ServiceTests/DockerComposeTests.cs
+++ b/Ductus.FluentDocker.Tests/ServiceTests/DockerComposeTests.cs
@@ -1,14 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Ductus.FluentDocker.Builders;
+using Ductus.FluentDocker.Common;
 using Ductus.FluentDocker.Model.Common;
 using Ductus.FluentDocker.Model.Compose;
+using Ductus.FluentDocker.Services;
 using Ductus.FluentDocker.Services.Impl;
 using Ductus.FluentDocker.Tests.Extensions;
 using Ductus.FluentDocker.Services.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BindingFlags = System.Reflection.BindingFlags;
+
 // ReSharper disable StringLiteralTypo
 
 namespace Ductus.FluentDocker.Tests.ServiceTests
@@ -39,6 +45,86 @@ namespace Ductus.FluentDocker.Tests.ServiceTests
 
         Assert.IsTrue(installPage.IndexOf("https://wordpress.org/", StringComparison.Ordinal) != -1);
       }
+    }
+
+    [TestMethod]
+    [DataRow(new[] { "non-existens-docker-compose1.yml" })]
+    [DataRow(new[] { "non-existens-docker-compose1.yml", "non-existens-docker-compose2.yml" })]
+    public void StartErrorMessageShallContainDockerComposeFilePaths(string[] nonExistentComposeFiles)
+    {
+      var svc = new DockerComposeCompositeService(DockerHost, new DockerComposeConfig
+      {
+        ComposeFilePath = new List<string>(nonExistentComposeFiles),
+        ForceRecreate = true,
+        RemoveOrphans = true,
+        StopOnDispose = true
+      });
+
+      var ex = Assert.ThrowsException<FluentDockerException>(() => svc.Start());
+
+      foreach (var nonExistentComposeFile in nonExistentComposeFiles)
+      {
+        Assert.IsTrue(ex.Message.Contains(nonExistentComposeFile));
+      }
+    }
+
+    [TestMethod]
+    [DataRow(new[] { "non-existens-docker-compose1.yml" })]
+    [DataRow(new[] { "non-existens-docker-compose1.yml", "non-existens-docker-compose2.yml" })]
+    public void DisposeErrorMessageShallContainDockerComposeFilePaths(string[] nonExistentComposeFiles)
+    {
+      var svc = new DockerComposeCompositeService(DockerHost, new DockerComposeConfig
+      {
+        ComposeFilePath = new List<string>(nonExistentComposeFiles),
+        ForceRecreate = true,
+        RemoveOrphans = true,
+        StopOnDispose = true
+      });
+
+      // ReSharper disable once AccessToDisposedClosure
+      var ex = Assert.ThrowsException<FluentDockerException>(() => svc.Dispose());
+
+      foreach (var nonExistentComposeFile in nonExistentComposeFiles)
+      {
+        Assert.IsTrue(ex.Message.Contains(nonExistentComposeFile));
+      }
+    }
+
+    [TestMethod]
+    [DataRow(new[] { "docker-compose1.yml" })]
+    [DataRow(new[] { "docker-compose1.yml", "docker-compose2.yml" })]
+    public void CompositeBuilderBuildErrorNoHostFoundShallContainComposeFilePaths(string[] composeFiles)
+    {
+      var builder = ((CompositeBuilder)typeof(CompositeBuilder)
+          .GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
+          .First()
+          .Invoke(new object[] {new BuilderFake(), null}))
+        .FromFile(composeFiles);
+
+      var ex = Assert.ThrowsException<FluentDockerException>(() => builder.Build());
+
+      foreach (var nonExistentComposeFile in composeFiles)
+      {
+        Assert.IsTrue(ex.Message.Contains(nonExistentComposeFile));
+      }
+    }
+
+    private class BuilderFake : IBuilder
+    {
+      /// <inheritdoc />
+      public Option<IBuilder> Parent { get; } = new Option<IBuilder>(null);
+
+      /// <inheritdoc />
+      public Option<IBuilder> Root { get; } = new Option<IBuilder>(null);
+
+      /// <inheritdoc />
+      public IReadOnlyCollection<IBuilder> Children { get; } = new ReadOnlyCollection<IBuilder>(new List<IBuilder>());
+
+      /// <inheritdoc />
+      public IBuilder Create() => null;
+
+      /// <inheritdoc />
+      public IService Build() => null;
     }
   }
 }

--- a/Ductus.FluentDocker/Builders/CompositeBuilder.cs
+++ b/Ductus.FluentDocker/Builders/CompositeBuilder.cs
@@ -33,7 +33,7 @@ namespace Ductus.FluentDocker.Builders
       var host = FindHostService();
       if (!host.HasValue)
         throw new FluentDockerException(
-          $"Cannot build service using compose-file {_config.ComposeFilePath} since no host service is defined");
+          $"Cannot build service using compose-file(s) {string.Join(", ", _config.ComposeFilePath)} since no host service is defined");
 
       var container = new DockerComposeCompositeService(host.Value, _config);
 

--- a/Ductus.FluentDocker/Services/Impl/DockerComposeCompositeService.cs
+++ b/Ductus.FluentDocker/Services/Impl/DockerComposeCompositeService.cs
@@ -47,7 +47,7 @@ namespace Ductus.FluentDocker.Services.Impl
         if (!result.Success)
         {
           State = ServiceRunningState.Unknown;
-          throw new FluentDockerException($"Could not dispose composite service {_config.ComposeFilePath}");
+          throw new FluentDockerException($"Could not dispose composite service from file(s) {string.Join(", ", _config.ComposeFilePath)}");
         }
 
         State = ServiceRunningState.Removed;
@@ -121,7 +121,7 @@ namespace Ductus.FluentDocker.Services.Impl
           host.Certificates, _config.ComposeFilePath.ToArray());
 
         if (!upr.Success)
-          throw new FluentDockerException($"Could not resume composite service {_config.ComposeFilePath}");
+          throw new FluentDockerException($"Could not resume composite service from file(s) {string.Join(", ", _config.ComposeFilePath)}");
 
         State = ServiceRunningState.Running;
         return;
@@ -142,7 +142,7 @@ namespace Ductus.FluentDocker.Services.Impl
       {
         State = ServiceRunningState.Unknown;
         throw new FluentDockerException(
-          $"Could not start composite service {_config.ComposeFilePath} - result: {result}");
+          $"Could not start composite service with file(s) {string.Join(", ", _config.ComposeFilePath)} - result: {result}");
       }
 
       var containers = host.Host.ComposePs(_config.AlternativeServiceName, _config.Services, _config.EnvironmentNameValue,
@@ -175,7 +175,7 @@ namespace Ductus.FluentDocker.Services.Impl
         host.Certificates, _config.ComposeFilePath.ToArray());
 
       if (!pause.Success)
-        throw new FluentDockerException($"Could not pause composite service {_config.ComposeFilePath}");
+        throw new FluentDockerException($"Could not pause composite service from file(s) {string.Join(", ", _config.ComposeFilePath)}");
 
       State = ServiceRunningState.Paused;
     }
@@ -202,7 +202,7 @@ namespace Ductus.FluentDocker.Services.Impl
       if (!result.Success)
       {
         State = ServiceRunningState.Unknown;
-        throw new FluentDockerException($"Could not stop composite service {_config.ComposeFilePath}");
+        throw new FluentDockerException($"Could not stop composite service from file(s) {string.Join(", ", _config.ComposeFilePath)}");
       }
 
       State = ServiceRunningState.Stopped;
@@ -219,7 +219,7 @@ namespace Ductus.FluentDocker.Services.Impl
       if (!result.Success)
       {
         State = ServiceRunningState.Unknown;
-        throw new FluentDockerException($"Could not remove composite service {_config.ComposeFilePath}");
+        throw new FluentDockerException($"Could not remove composite service from file(s) {string.Join(", ", _config.ComposeFilePath)}");
       }
 
       State = ServiceRunningState.Removed;


### PR DESCRIPTION
Since we can have multiple `docker-compose.yml` files the error messages at various places should be corrected. Otherwise we get error messages like this one:
```
Ductus.FluentDocker.Common.FluentDockerException: 
Could not start composite service System.Collections.Generic.List`1[System.String] - result: build path 
```