### PR TITLE
Bug compose copyon

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "dont"
+    ]
+}

--- a/Ductus.FluentDocker/Services/Impl/DockerComposeCompositeService.cs
+++ b/Ductus.FluentDocker/Services/Impl/DockerComposeCompositeService.cs
@@ -133,7 +133,7 @@ namespace Ductus.FluentDocker.Services.Impl
         _config.NoRecreate, _config.NoBuild, _config.ForceBuild,
         _config.TimeoutSeconds == TimeSpan.Zero ? (TimeSpan?)null : _config.TimeoutSeconds, _config.RemoveOrphans,
         _config.UseColor,
-        false,
+        true/*noStart*/,
         _config.Services,
         _config.EnvironmentNameValue,
         host.Certificates, _config.ComposeFilePath.ToArray());
@@ -144,6 +144,18 @@ namespace Ductus.FluentDocker.Services.Impl
         throw new FluentDockerException(
           $"Could not start composite service with file(s) {string.Join(", ", _config.ComposeFilePath)} - result: {result}");
       }
+
+      State = ServiceRunningState.Starting
+
+      var result = host.Host.ComposeUp(_config.AlternativeServiceName, 
+        false/*forceRecreate*/,false/*noRecreate*/,false/*dontBuild*/, false/*buildBeforeCreate*/,
+        _config.TimeoutSeconds == TimeSpan.Zero ? (TimeSpan?)null : _config.TimeoutSeconds, _config.RemoveOrphans,
+        _config.UseColor,
+        true/*noStart*/,
+        _config.Services,
+        _config.EnvironmentNameValue,
+        host.Certificates, _config.ComposeFilePath.ToArray());
+
 
       var containers = host.Host.ComposePs(_config.AlternativeServiceName, _config.Services, _config.EnvironmentNameValue,
         host.Certificates, _config.ComposeFilePath.ToArray());

--- a/Ductus.FluentDocker/Services/Impl/DockerComposeCompositeService.cs
+++ b/Ductus.FluentDocker/Services/Impl/DockerComposeCompositeService.cs
@@ -142,12 +142,12 @@ namespace Ductus.FluentDocker.Services.Impl
       {
         State = ServiceRunningState.Unknown;
         throw new FluentDockerException(
-          $"Could not start composite service with file(s) {string.Join(", ", _config.ComposeFilePath)} - result: {result}");
+          $"Could not create composite service with file(s) {string.Join(", ", _config.ComposeFilePath)} - result: {result}");
       }
 
       State = ServiceRunningState.Starting;
 
-      var result = host.Host.ComposeUp(_config.AlternativeServiceName, 
+      result = host.Host.ComposeUp(_config.AlternativeServiceName, 
         false/*forceRecreate*/,false/*noRecreate*/,false/*dontBuild*/, false/*buildBeforeCreate*/,
         _config.TimeoutSeconds == TimeSpan.Zero ? (TimeSpan?)null : _config.TimeoutSeconds, _config.RemoveOrphans,
         _config.UseColor,
@@ -156,6 +156,11 @@ namespace Ductus.FluentDocker.Services.Impl
         _config.EnvironmentNameValue,
         host.Certificates, _config.ComposeFilePath.ToArray());
 
+      if (!result.Success)
+      {
+        throw new FluentDockerException(
+          $"Could not start composite service with file(s) {string.Join(", ", _config.ComposeFilePath)} - result: {result}");
+      }
 
       var containers = host.Host.ComposePs(_config.AlternativeServiceName, _config.Services, _config.EnvironmentNameValue,
         host.Certificates, _config.ComposeFilePath.ToArray());

--- a/Ductus.FluentDocker/Services/Impl/DockerComposeCompositeService.cs
+++ b/Ductus.FluentDocker/Services/Impl/DockerComposeCompositeService.cs
@@ -145,7 +145,7 @@ namespace Ductus.FluentDocker.Services.Impl
           $"Could not start composite service with file(s) {string.Join(", ", _config.ComposeFilePath)} - result: {result}");
       }
 
-      State = ServiceRunningState.Starting
+      State = ServiceRunningState.Starting;
 
       var result = host.Host.ComposeUp(_config.AlternativeServiceName, 
         false/*forceRecreate*/,false/*noRecreate*/,false/*dontBuild*/, false/*buildBeforeCreate*/,


### PR DESCRIPTION
Fixes the problems in Issue #175 by firing up the compose with --no-start and then do a proper compose up and thereby the state transition from ServiceRunningState.x -> ServiceRunningState.Starting -> ServiceRunningState.Running. Hence, all hooks is now executed properly (as with plain docker).

Hence this closes #175 