### PR TITLE
Add features to Docker FileBuilder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
     "cSpell.words": [
         "Ductus",
-        "dont"
+        "dont",
+        "myimg",
+        "mytag"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "Ductus",
         "dont"
     ]
 }

--- a/Ductus.FluentDocker/Builders/FileBuilder.cs
+++ b/Ductus.FluentDocker/Builders/FileBuilder.cs
@@ -76,9 +76,27 @@ namespace Ductus.FluentDocker.Builders
       return this;
     }
 
+    /// <summary>
+    /// Specified a simplified from command with the image name (and optional tag name) only!
+    /// </summary>
+    /// <param name="from">The image and optional tag name.</param>
+    /// <returns>Itself for fluent access.</returns>
     public FileBuilder UseParent(string from)
     {
       _config.Commands.Add(new FromCommand(from));
+      return this;
+    }
+
+    /// <summary>
+    /// Specifies the _FROM_ command.
+    /// </summary>
+    /// <param name="imageAndTag">The image to derive from and a optional (colon) tag, e.g. myimg:mytag</param>
+    /// <param name="asName">An optional alias.</param>
+    /// <param name="platform">An optional platform such linux/amd64 or windows/amd64.</param>
+    /// <returns>Itself for fluent access.</returns>
+    public FileBuilder From(TemplateString imageAndTag, TemplateString asName = null, TemplateString platform = null)
+    {
+      _config.Commands.Add(new FromCommand(imageAndTag, asName, platform));
       return this;
     }
 
@@ -127,9 +145,22 @@ namespace Ductus.FluentDocker.Builders
       return this;
     }
 
-    public FileBuilder Copy(TemplateString source, TemplateString dest)
+    /// <summary>
+    /// This generates the _COPY_ command.
+    /// </summary>
+    /// <param name="source">From directory.</param>
+    /// <param name="dest">To directory.</param>
+    /// <param name="chownUserAndGroup">Optional --chown user:group.</param>
+    /// <param name="fromAlias">
+    /// Optional source location from earlier buildstage FROM ... AS alias. This will 
+    /// generate --from=aliasname in the _COPY_ command and hence reference a earlier
+    /// _FROM ... AS aliasname_ buildstep as source.
+    /// </param>
+    /// <returns>Itself for fluent access.</returns>
+    public FileBuilder Copy(TemplateString source, TemplateString dest,
+    TemplateString chownUserAndGroup = null, TemplateString fromAlias = null)
     {
-      _config.Commands.Add(new CopyCommand(source, dest));
+      _config.Commands.Add(new CopyCommand(source, dest, chownUserAndGroup, fromAlias));
       return this;
     }
 
@@ -142,6 +173,59 @@ namespace Ductus.FluentDocker.Builders
     public FileBuilder ExposePorts(params int[] ports)
     {
       _config.Commands.Add(new ExposeCommand(ports));
+      return this;
+    }
+
+    /// <summary>
+    /// Adds a _ENV_ command to _dockerfile_. The value of each name value pair is automatically
+    /// double quoted. Hence, it is possible to write spaces etc in the string without double quoting it.
+    /// </summary>
+    /// <param name="nameValue">Name=value array.</param>
+    /// <returns>Itself for fluent access.</returns>
+    /// <remarks>The name value is separated by space on same line.</remarks>
+    public FileBuilder Environment(params TemplateString[] nameValue)
+    {
+      _config.Commands.Add(new EnvCommand(nameValue));
+      return this;
+    }
+
+        /// <summary>
+    /// Adds a _LABEL_ command to _dockerfile_. The value of each name value pair is automatically
+    /// double quoted. Hence, it is possible to write spaces etc in the string without double quoting it.
+    /// </summary>
+    /// <param name="nameValue">Name=value array.</param>
+    /// <returns>Itself for fluent access.</returns>
+    /// <remarks>The name value is separated by space on same line.</remarks>
+    public FileBuilder Label(params TemplateString[] nameValue)
+    {
+      _config.Commands.Add(new LabelCommand(nameValue));
+      return this;
+    }
+
+    /// <summary>
+    /// Adds a _ARG_ command in _dockerfile_ with the optional _defaultValue_.
+    /// </summary>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="defaultValue">Optional a default value for the argument.</param>
+    /// <returns>Itself for fluent access.</returns>
+    public FileBuilder Arguments(TemplateString name, TemplateString defaultValue = null) {
+      _config.Commands.Add(new ArgCommand(name, defaultValue));
+      return this;
+    }
+
+    public FileBuilder Entrypoint(string command, params string[] args)
+    {
+      _config.Commands.Add(new EntrypointCommand(command, args));
+      return this;
+    }
+
+    public FileBuilder User(TemplateString user, TemplateString group = null) {
+      _config.Commands.Add(new UserCommand(user, group));
+      return this;
+    }
+
+    public FileBuilder Volume(params TemplateString[] mountpoints) {
+      _config.Commands.Add(new VolumeCommand(mountpoints));
       return this;
     }
 

--- a/Ductus.FluentDocker/Builders/ImageBuilder.cs
+++ b/Ductus.FluentDocker/Builders/ImageBuilder.cs
@@ -61,8 +61,23 @@ namespace Ductus.FluentDocker.Builders
       return new ImageBuilder(this);
     }
 
-    public FileBuilder From(string from)
+    /// <summary>
+    /// Creates a _dockerfile_ builder.
+    /// </summary>
+    /// <param name="from">
+    /// Optional image to specify as FROM. If omitted, it is up to the caller to specify _UseParent_ or _From_.
+    /// </param>
+    /// <returns>
+    /// A newly created filebuilder. If empty or null string the `FileBuilder` is empty. Otherwise it has populated
+    /// the `FileBuilder` with a parent of the specified image name (via _UseParent()_).
+    /// </returns>
+    public FileBuilder From(string from = null)
     {
+      if (string.IsNullOrEmpty(from))
+      {
+        return _fileBuilder = new FileBuilder(this);
+      }
+
       return _fileBuilder = new FileBuilder(this).UseParent(from);
     }
 

--- a/Ductus.FluentDocker/Extensions/EnvironmentExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/EnvironmentExtensions.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Ductus.FluentDocker.Common;
 using Ductus.FluentDocker.Executors;
+using Ductus.FluentDocker.Model.Common;
 
 namespace Ductus.FluentDocker.Extensions
 {
@@ -32,6 +35,36 @@ namespace Ductus.FluentDocker.Extensions
       }
 
       return executor;
+    }
+
+    /// <summary>
+    /// This function will extract the name value and verify that is is valid. It will then
+    /// make sure that the value is wrapped inside double quotes if not yet wrapped.
+    /// </summary>
+    /// <param name="nameValue">The name=value strings</param>
+    /// <returns>A list of name=value string with the value wrapped inside double quotes.</returns>
+    public static IList<string> WrapValue(this TemplateString[] nameValue)
+    {
+
+      var list = new List<string>();
+      foreach (var s in nameValue.Select(s => s.Rendered))
+      {
+
+        var index = s.IndexOf('=');
+        if (-1 == index)
+        {
+          throw new FluentDockerException(
+              $"Expected format name=value, missing equal sign in the name value string: '{s}'"
+            );
+        }
+
+        var name = s.Substring(0, index);
+        var value = s.Substring(index + 1, s.Length - index - 1).WrapWithChar("\"");
+
+        list.Add($"{name}={value}");
+      }
+
+      return list;
     }
   }
 }

--- a/Ductus.FluentDocker/Extensions/StringExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/StringExtensions.cs
@@ -1,0 +1,26 @@
+
+namespace Ductus.FluentDocker.Extensions {
+    public static class StringExtensions {
+
+        /// <summary>
+        /// This function will wrap the string s with string c (start and end) if
+        /// not already existant. If already exist, it will leave it, hence it
+        /// do not double wrap.
+        /// </summary>
+        /// <param name="s">The string to wrap.</param>
+        /// <param name="c">The string to check and wrap with if not existing.</param>
+        /// <returns>The wrapped string.</returns>
+        public static string WrapWithChar(this string s, string c) {
+
+            if (!s.StartsWith(c)) {
+                s = c + s;
+            }
+
+            if (!s.EndsWith(c)) {
+                s = s + c;
+            }
+
+            return s;
+        }   
+    }
+}

--- a/Ductus.FluentDocker/Model/Builders/FileBuilder/ArgCommand.cs
+++ b/Ductus.FluentDocker/Model/Builders/FileBuilder/ArgCommand.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ductus.FluentDocker.Common;
+using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Model.Common;
+
+namespace Ductus.FluentDocker.Model.Builders.FileBuilder
+{
+  public sealed class ArgCommand : ICommand
+  {
+    public ArgCommand(TemplateString name, TemplateString defaultValue = null)
+    {
+      if (null == name || string.IsNullOrEmpty(name.Rendered))
+      {
+        throw new FluentDockerException("Must, at least, specify the argument name in a ARG");
+      }
+
+
+      Name = name.Rendered;
+
+      if (null != defaultValue && !string.IsNullOrEmpty(defaultValue.Rendered))
+      {
+        DefaultValue = defaultValue.Rendered;
+      }
+    }
+
+    public string Name { get; }
+    public string DefaultValue { get; }
+
+    public override string ToString()
+    {
+      if (string.IsNullOrEmpty(DefaultValue))
+      {
+        return $"ARG {Name}";
+      }
+
+      return $"ARG {Name}={DefaultValue}";
+    }
+  }
+}

--- a/Ductus.FluentDocker/Model/Builders/FileBuilder/CopyCommand.cs
+++ b/Ductus.FluentDocker/Model/Builders/FileBuilder/CopyCommand.cs
@@ -1,19 +1,54 @@
-﻿namespace Ductus.FluentDocker.Model.Builders.FileBuilder
+﻿using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Model.Common;
+
+namespace Ductus.FluentDocker.Model.Builders.FileBuilder
 {
   public sealed class CopyCommand : ICommand
   {
-    public CopyCommand(string from, string to)
+    /// <summary>
+    /// This generates the _COPY_ command.
+    /// </summary>
+    /// <param name="from">From directory.</param>
+    /// <param name="to">To directory.</param>
+    /// <param name="chownUserAndGroup">Optional --chown user:group.</param>
+    /// <param name="fromAlias">
+    /// Optional source location from earlier buildstage FROM ... AS alias. This will 
+    /// generate --from=aliasname in the _COPY_ command and hence reference a earlier
+    /// _FROM ... AS aliasname_ buildstep as source.
+    /// </param>
+    public CopyCommand(TemplateString from, TemplateString to, 
+      TemplateString chownUserAndGroup = null, TemplateString fromAlias = null)
     {
-      From = from;
-      To = to;
+      From = from.Rendered.WrapWithChar("\"");
+      To = to.Rendered.WrapWithChar("\"");
+
+      if (null != chownUserAndGroup && !string.IsNullOrEmpty(chownUserAndGroup.Rendered)) {
+        Chown = chownUserAndGroup.Rendered;
+      }
+
+      if (null != fromAlias && !string.IsNullOrEmpty(fromAlias.Rendered)) {
+        Alias = fromAlias.Rendered;
+      }
     }
 
     public string From { get; }
     public string To { get; }
+    public string Alias { get; }
+    public string Chown { get; }
 
     public override string ToString()
     {
-      return $"COPY {From} {To}";
+      string s = "COPY";
+
+      if (!string.IsNullOrEmpty(Chown)) {
+        s = $"{s} --chown={Chown}";
+      }
+
+      if (!string.IsNullOrEmpty(Alias)) {
+        s = $"{s} --from={Alias}";
+      }
+
+      return $"{s} [{From},{To}]";
     }
   }
 }

--- a/Ductus.FluentDocker/Model/Builders/FileBuilder/EntrypointCommand.cs
+++ b/Ductus.FluentDocker/Model/Builders/FileBuilder/EntrypointCommand.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Ductus.FluentDocker.Model.Builders.FileBuilder
+{
+  public sealed class EntrypointCommand : ICommand
+  {
+    public EntrypointCommand(string executable, params string[] args)
+    {
+      Executable = executable;
+      Arguments = args ?? Array.Empty<string>();
+    }
+
+    public string Executable { get; }
+    public string[] Arguments { get; }
+
+    public override string ToString()
+    {
+      return $"ENTRYPOINT [\"{Executable}{string.Join("\",\"", Arguments)}\"]";
+    }
+  }
+}

--- a/Ductus.FluentDocker/Model/Builders/FileBuilder/EnvCommand.cs
+++ b/Ductus.FluentDocker/Model/Builders/FileBuilder/EnvCommand.cs
@@ -1,0 +1,29 @@
+using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Model.Common;
+using System.Linq;
+
+namespace Ductus.FluentDocker.Model.Builders.FileBuilder
+{
+  public sealed class EnvCommand : ICommand
+  {
+    public EnvCommand(params TemplateString[] nameValue)
+    {
+        if (nameValue == null || 0 == nameValue.Length) {
+            NameValue = new string[0];
+        } else {
+            NameValue = NameValue = nameValue.WrapValue().ToArray();
+        }
+    }
+
+    public string[] NameValue { get; internal set; }
+
+    public override string ToString()
+    {
+      if (0 == NameValue.Length) {
+          return "";
+      }
+
+      return $"ENV {string.Join(" ", NameValue)}";
+    }
+  }
+}

--- a/Ductus.FluentDocker/Model/Builders/FileBuilder/FromCommand.cs
+++ b/Ductus.FluentDocker/Model/Builders/FileBuilder/FromCommand.cs
@@ -1,17 +1,54 @@
-﻿namespace Ductus.FluentDocker.Model.Builders.FileBuilder
+﻿using Ductus.FluentDocker.Common;
+using Ductus.FluentDocker.Model.Common;
+
+namespace Ductus.FluentDocker.Model.Builders.FileBuilder
 {
   public sealed class FromCommand : ICommand
   {
-    public FromCommand(string @from)
+    /// <summary>
+    /// Specifies the _FROM_ command.
+    /// </summary>
+    /// <param name="imageAndTag">The image to derive from and a optional (colon) tag, e.g. myimg:mytag</param>
+    /// <param name="asName">An optional alias.</param>
+    /// <param name="platform">An optional platform such linux/amd64 or windows/amd64.</param>
+    public FromCommand(TemplateString imageAndTag, TemplateString asName = null, TemplateString platform = null)
     {
-      From = @from;
+      if (null == imageAndTag || string.IsNullOrEmpty(imageAndTag.Rendered)) {
+        throw new FluentDockerException("FROM requires atleast a image name");
+      }
+
+      ImageAndTag = imageAndTag;
+
+      if (null != asName && !string.IsNullOrEmpty(asName.Rendered))
+      {
+        Alias = asName.Rendered;
+      }
+
+      if (null != platform && !string.IsNullOrEmpty(platform.Rendered))
+      {
+        Platform = platform.Rendered;
+      }
     }
 
-    public string From { get; }
+    public string ImageAndTag { get; }
+    public string Platform { get; }
+    public string Alias { get; }
 
     public override string ToString()
     {
-      return $"FROM {From}";
+      var s = "FROM";
+
+      if (!string.IsNullOrEmpty(Platform)) {
+        s = $"{s} --platform={Platform}";
+      }
+
+      s = $"{s} {ImageAndTag}";
+
+      if (!string.IsNullOrEmpty(Alias)) {
+        s = $"{s} {Alias}";
+      }
+
+      return s;
     }
   }
 }

--- a/Ductus.FluentDocker/Model/Builders/FileBuilder/LabelCommand.cs
+++ b/Ductus.FluentDocker/Model/Builders/FileBuilder/LabelCommand.cs
@@ -1,0 +1,33 @@
+using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Model.Common;
+using System.Linq;
+
+namespace Ductus.FluentDocker.Model.Builders.FileBuilder
+{
+  public sealed class LabelCommand : ICommand
+  {
+    public LabelCommand(params TemplateString[] nameValue)
+    {
+      if (nameValue == null || 0 == nameValue.Length)
+      {
+        NameValue = new string[0];
+      }
+      else
+      {
+        NameValue = nameValue.WrapValue().ToArray();
+      }
+    }
+
+    public string[] NameValue { get; internal set; }
+
+    public override string ToString()
+    {
+      if (0 == NameValue.Length)
+      {
+        return "";
+      }
+
+      return $"LABEL {string.Join(" ", NameValue)}";
+    }
+  }
+}

--- a/Ductus.FluentDocker/Model/Builders/FileBuilder/UserCommand.cs
+++ b/Ductus.FluentDocker/Model/Builders/FileBuilder/UserCommand.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ductus.FluentDocker.Common;
+using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Model.Common;
+
+namespace Ductus.FluentDocker.Model.Builders.FileBuilder
+{
+  public sealed class UserCommand : ICommand
+  {
+    public UserCommand(TemplateString user, TemplateString group = null)
+    {
+      if (null == user || string.IsNullOrEmpty(user.Rendered))
+      {
+        throw new FluentDockerException("Must specify username or user id");
+      }
+
+
+      User = user.Rendered;
+
+      if (null != group && !string.IsNullOrEmpty(group.Rendered))
+      {
+        Group = group.Rendered;
+      }
+    }
+
+    public string User { get; }
+    public string Group { get; }
+
+    public override string ToString()
+    {
+      if (string.IsNullOrEmpty(Group))
+      {
+        return $"USER {User}";
+      }
+
+      return $"USER {User}:{Group}";
+    }
+  }
+}

--- a/Ductus.FluentDocker/Model/Builders/FileBuilder/VolumeCommand.cs
+++ b/Ductus.FluentDocker/Model/Builders/FileBuilder/VolumeCommand.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Model.Common;
+
+namespace Ductus.FluentDocker.Model.Builders.FileBuilder
+{
+  public sealed class VolumeCommand : ICommand
+  {
+    public VolumeCommand(params TemplateString[] mountpoints)
+    {
+      var list = new List<string>();
+      
+      foreach (var s in mountpoints.Select(s => s.Rendered))
+      {
+        list.Add(s.WrapWithChar("\""));
+      }
+
+      Mountpoints = list.ToArray();
+    }
+
+    public string[] Mountpoints { get; }
+
+    public override string ToString()
+    {
+      return $"VOLUME [\"{string.Join(",", Mountpoints)}\"]";
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a few enhancements to the `FileBuilder` to support a few issues and a bit more (while implementing it).

This adds the following commands:
* ENV
* ARG
* ENTRYPOINT
* LABEL
* USER
* VOLUME

Via the _Model/Builder/FileBuilder/ICommand_ structure.

Modified:
* _FROM_ to accept both platform (such as linux/amd64) and a alias name. This name may be referred using other commands.
* _COPY_ to accept chown user and group as well as _--from=alias_ to refer to a earlier build step _FROM ... AS alias_.

TODO: Add description when committing the rest.

This closes #177 when done. It also closes #178. In addition it also closes #179 when it is merged.
