### PR TITLE
Support for custom IHostService creation in HostBuilder

### DIFF
--- a/Ductus.FluentDocker/Builders/HostBuilder.cs
+++ b/Ductus.FluentDocker/Builders/HostBuilder.cs
@@ -1,17 +1,26 @@
 ﻿using System.Linq;
+using Ductus.FluentDocker.Model.Common;
 using Ductus.FluentDocker.Services;
 
 namespace Ductus.FluentDocker.Builders
 {
   public sealed class HostBuilder : BaseBuilder<IHostService>
   {
+    private IHostService customHostService;
+
     internal HostBuilder(IBuilder builder) : base(builder)
     {
     }
 
     public override IHostService Build()
     {
+
+      if (this.customHostService != null) {
+        return this.customHostService;
+      }
+
       return IsNative ? new Hosts().Native() : null;
+
     }
 
     protected override IBuilder InternalCreate()
@@ -24,6 +33,36 @@ namespace Ductus.FluentDocker.Builders
     public HostBuilder UseNative()
     {
       IsNative = true;
+      return this;
+    }
+
+    public HostBuilder UseHost(IHostService customHostService) {
+      this.customHostService = customHostService;
+      return this;
+    }
+
+   /// <summary>
+    /// Creates a `IHostService` based on a _URI_.
+    /// </summary>
+    /// <param name="uri">The _URI_ to the docker daemon.</param>
+    /// <param name="name">An optional name. If none is specified the _URI_ is the name.</param>
+    /// <param name="isNative">If the docker daemon is native or not. Default to true.</param>
+    /// <param name="stopWhenDisposed">If it should be stopped when disposed, default to false.</param>
+    /// <param name="isWindowsHost">If it is a docker daemon that controls windows containers or not. Default false.</param>
+    /// <param name="certificatePath">
+    /// Optional path to where certificates are located in order to do TLS communication with docker daemon. If not provided,
+    /// it will try to get it from the environment _DOCKER_CERT_PATH_.
+    /// </param>
+    /// <returns>Itself for fluent access.</returns>
+     public HostBuilder FromUri(
+      DockerUri uri,
+      string name = null,
+      bool isNative = true,
+      bool stopWhenDisposed = false,
+      bool isWindowsHost = false,
+      string certificatePath = null)
+    {
+      this.customHostService = new Hosts().FromUri(uri,name,isNative,stopWhenDisposed,isWindowsHost,certificatePath);
       return this;
     }
 

--- a/Ductus.FluentDocker/Services/Extensions/NetworkExtensions.cs
+++ b/Ductus.FluentDocker/Services/Extensions/NetworkExtensions.cs
@@ -107,19 +107,22 @@ namespace Ductus.FluentDocker.Services.Extensions
     /// <summary>Get extra long current timestamp</summary>
     private static long Millis => (long)((DateTime.UtcNow - Jan1St1970).TotalMilliseconds);
 
-/// <summary>
+    /// <summary>
     ///   Translates a docker exposed port and protocol (on format 'port/proto' e.g. '534/tcp') to a
     ///   host endpoint that can be contacted outside the container.
     /// </summary>
     /// <param name="ports">The ports from the <see cref="ContainerNetworkSettings.Ports" /> property.</param>
     /// <param name="portAndProto">The port and protocol string.</param>
     /// <param name="dockerUri">Optional docker uri to use when the address is 0.0.0.0 in the endpoint.</param>
-    /// <returns>A endpoint of the host exposed ip and port into the container port. If none is found, null is returned.</returns>
+    /// <returns>
+    /// A endpoint of the host exposed ip and port into the container port. 
+    /// If none is found, null is returned.
+    /// </returns>
     public static IPEndPoint ToHostPort(this Dictionary<string, HostIpEndpoint[]> ports, string portAndProto,
-      Uri dockerUri = null) 
-      {
-        return ToHostPortCustomResolver(ports, null, portAndProto, dockerUri);
-      }
+      Uri dockerUri = null)
+    {
+      return ToHostPortCustomResolver(ports, null, portAndProto, dockerUri);
+    }
 
     /// <summary>
     ///   Translates a docker exposed port and protocol (on format 'port/proto' e.g. '534/tcp') to a
@@ -133,22 +136,23 @@ namespace Ductus.FluentDocker.Services.Extensions
     /// <param name="dockerUri">Optional docker uri to use when the address is 0.0.0.0 in the endpoint.</param>
     /// <returns>A endpoint of the host exposed ip and port into the container port. If none is found, null is returned.</returns>
     public static IPEndPoint ToHostPortCustomResolver(
-      this Dictionary<string, HostIpEndpoint[]> ports, 
-      Func<Dictionary<string, HostIpEndpoint[]>,string, Uri, IPEndPoint> customResolver, 
+      this Dictionary<string, HostIpEndpoint[]> ports,
+      Func<Dictionary<string, HostIpEndpoint[]>, string, Uri, IPEndPoint> customResolver,
       string portAndProto,
       Uri dockerUri = null)
     {
 
-      if (customResolver != null) 
+      if (customResolver != null)
       {
         var ep = customResolver.Invoke(ports, portAndProto, dockerUri);
-        
-        if (ep != null) {
+
+        if (ep != null)
+        {
           return ep;
         }
 
       }
-      
+
       if (null == ports || string.IsNullOrEmpty(portAndProto))
         return null;
 

--- a/Ductus.FluentDocker/Services/Hosts.cs
+++ b/Ductus.FluentDocker/Services/Hosts.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Ductus.FluentDocker.Commands;
 using Ductus.FluentDocker.Common;
 using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Model.Common;
 using Ductus.FluentDocker.Services.Impl;
 
 namespace Ductus.FluentDocker.Services
@@ -45,6 +46,43 @@ namespace Ductus.FluentDocker.Services
           Environment.GetEnvironmentVariable(DockerHostService.DockerCertPath));
 
       return null;
+    }
+
+    /// <summary>
+    /// Creates a `IHostService` based on a _URI_.
+    /// </summary>
+    /// <param name="uri">The _URI_ to the docker daemon.</param>
+    /// <param name="name">An optional name. If none is specified the _URI_ is the name.</param>
+    /// <param name="isNative">If the docker daemon is native or not. Default to true.</param>
+    /// <param name="stopWhenDisposed">If it should be stopped when disposed, default to false.</param>
+    /// <param name="isWindowsHost">If it is a docker daemon that controls windows containers or not. Default false.</param>
+    /// <param name="certificatePath">
+    /// Optional path to where certificates are located in order to do TLS communication with docker daemon. If not provided,
+    /// it will try to get it from the environment _DOCKER_CERT_PATH_.
+    /// </param>
+    /// <returns>A newly created host service.</returns>
+    public IHostService FromUri(
+      DockerUri uri,
+      string name = null,
+      bool isNative = true,
+      bool stopWhenDisposed = false,
+      bool isWindowsHost = false,
+      string certificatePath = null)
+    {
+
+      if (string.IsNullOrEmpty(certificatePath))
+      {
+        certificatePath = Environment.GetEnvironmentVariable(DockerHostService.DockerCertPath);
+      }
+
+      if (string.IsNullOrEmpty(name))
+      {
+        name = uri.ToString();
+      }
+
+      return new DockerHostService(
+        name, isNative, stopWhenDisposed, uri.ToString(), certificatePath, isWindowsHost
+      );
     }
 
     public IHostService FromMachineName(string name, bool isWindowsHost = false, bool throwIfNotStarted = false)


### PR DESCRIPTION
Add methods:

* `FromUri` that uses a `DockerUri` to create a `IHostService`. This _uri_ is arbitary. It also support other properties (_see below_).

```cs
   public HostBuilder FromUri(
      DockerUri uri,
      string name = null,
      bool isNative = true,
      bool stopWhenDisposed = false,
      bool isWindowsHost = false,
      string certificatePath = null) {/*...*/}
```

It will use _"sensible"_ defaults on all parameters. Most of the case the _uri_ is sufficient. For example if not providing the _certificatePath_ it will try to get it from the environment _DOCKER_CERT_PATH_. If not found in the environment, it will default to none.

* `UseHost` that takes a instantiated `IHostService` implementation.

this closes isse #185 