### PR TITLE
Make `envtest.sh` executable and add shebang

### DIFF
--- a/Ductus.FluentDocker.Tests/Resources/Scripts/envtest.sh
+++ b/Ductus.FluentDocker.Tests/Resources/Scripts/envtest.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 echo $FD_CUSTOM_ENV


### PR DESCRIPTION
On macOS, tests running the `envtest.sh` script would fail with a permission denied exception because the script is not exectuable:
```
System.ComponentModel.Win32Exception: Permission denied
   at Interop.Sys.ForkAndExecProcess(String filename, String[] argv, String[] envp, String cwd, Boolean redirectStdin, Boolean redirectStdout, Boolean redirectStderr, Boolean setUser, UInt32 userId, UInt32 groupId, Int32& lpChildPid, Int32& stdinFd, Int32& stdoutFd, Int32& stderrFd, Boolean shouldThrow)
   at System.Diagnostics.Process.StartCore(ProcessStartInfo startInfo)
   at System.Diagnostics.Process.Start()
   at Ductus.FluentDocker.Executors.ProcessExecutor`2.Execute() in Ductus.FluentDocker/Executors/ProcessExecutor.cs:line 75
   at Ductus.FluentDocker.Tests.ProcessTests.ProcessEnvironmentTest.ProcessShallPassCustomEnvironment() in Ductus.FluentDocker.Tests/ProcessTests/ProcessEnvironmentTest.cs:line 24
```

Also add `#!/bin/sh` to avoid exec format error:
```
System.ComponentModel.Win32Exception: Exec format error
   at System.Diagnostics.Process.ForkAndExecProcess(String filename, String[] argv, String[] envp, String cwd, Boolean redirectStdin, Boolean redirectStdout, Boolean redirectStderr, Boolean setCredentials, UInt32 userId, UInt32 groupId, UInt32[] groups, Int32& stdinFd, Int32& stdoutFd, Int32& stderrFd, Boolean usesTerminal, Boolean throwOnNoExec)
   at System.Diagnostics.Process.StartCore(ProcessStartInfo startInfo)
   at System.Diagnostics.Process.Start()
   at Ductus.FluentDocker.Executors.ProcessExecutor`2.Execute() in Ductus.FluentDocker/Executors/ProcessExecutor.cs:line 75
   at Ductus.FluentDocker.Tests.ProcessTests.ProcessEnvironmentTest.ProcessShallPassCustomEnvironment() in Ductus.FluentDocker.Tests/ProcessTests/ProcessEnvironmentTest.cs:line 24
```