### PR TITLE
Use PublishAllPorts instead of explicit port mappings in unit tests

### DIFF
--- a/Ductus.FluentDocker.Tests/CommandTests/ClientStreamCommandTests.cs
+++ b/Ductus.FluentDocker.Tests/CommandTests/ClientStreamCommandTests.cs
@@ -32,7 +32,7 @@ namespace Ductus.FluentDocker.Tests.CommandTests
         {
           var cmd = _docker.Run("postgres:9.6-alpine", new ContainerCreateParams
           {
-            PortMappings = new[] { "40001:5432" },
+            PublishAllPorts = true,
             Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" }
           }, _certificates);
 
@@ -66,7 +66,7 @@ namespace Ductus.FluentDocker.Tests.CommandTests
       {
         var cmd = _docker.Run("postgres:9.6-alpine", new ContainerCreateParams
         {
-          PortMappings = new[] { "40001:5432" },
+          PublishAllPorts = true,
           Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" }
         }, _certificates);
 
@@ -111,7 +111,7 @@ namespace Ductus.FluentDocker.Tests.CommandTests
       {
         var cmd = _docker.Run("postgres:9.6-alpine", new ContainerCreateParams
         {
-          PortMappings = new[] { "40001:5432" },
+          PublishAllPorts = true,
           Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" }
         }, _certificates);
 
@@ -159,7 +159,7 @@ namespace Ductus.FluentDocker.Tests.CommandTests
       {
         var cmd = _docker.Run("postgres:9.6-alpine", new ContainerCreateParams
         {
-          PortMappings = new[] { "40001:5432" },
+          PublishAllPorts = true,
           Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" }
         }, _certificates);
 

--- a/Ductus.FluentDocker.Tests/CommandTests/DockerClientCommandTests.cs
+++ b/Ductus.FluentDocker.Tests/CommandTests/DockerClientCommandTests.cs
@@ -333,7 +333,7 @@ namespace Ductus.FluentDocker.Tests.CommandTests
       {
         var cmd = _docker.Run("postgres:9.6-alpine", new ContainerCreateParams
         {
-          PortMappings = new[] { "40001:5432" },
+          PublishAllPorts = true,
           Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" }
         }, _certificates);
 

--- a/Ductus.FluentDocker.Tests/CommandTests/NetworkCommandTests.cs
+++ b/Ductus.FluentDocker.Tests/CommandTests/NetworkCommandTests.cs
@@ -122,7 +122,7 @@ namespace Ductus.FluentDocker.Tests.CommandTests
 
         var cmd = _docker.Run("postgres:9.6-alpine", new ContainerCreateParams
         {
-          PortMappings = new[] { "40001:5432" },
+          PublishAllPorts = true,
           Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" },
           Network = "unit-test-nw",
           Ipv4 = "10.18.0.22"
@@ -156,7 +156,7 @@ namespace Ductus.FluentDocker.Tests.CommandTests
       {
         var cmd = _docker.Run("postgres:9.6-alpine", new ContainerCreateParams
         {
-          PortMappings = new[] { "40001:5432" },
+          PublishAllPorts = true,
           Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" }
         }, _certificates);
 

--- a/Ductus.FluentDocker.Tests/FluentApiTests/FluentContainerBasicTests.cs
+++ b/Ductus.FluentDocker.Tests/FluentApiTests/FluentContainerBasicTests.cs
@@ -136,7 +136,6 @@ namespace Ductus.FluentDocker.Tests.FluentApiTests
         var container =
           Fd.UseContainer()
             .UseImage("postgres:9.6-alpine")
-            .ExposePort(40001, 5432)
             .WithEnvironment("POSTGRES_PASSWORD=mysecretpassword")
             .Build()
             .Start())

--- a/Ductus.FluentDocker.Tests/ServiceTests/ContainerServiceBasicTests.cs
+++ b/Ductus.FluentDocker.Tests/ServiceTests/ContainerServiceBasicTests.cs
@@ -172,7 +172,7 @@ namespace Ductus.FluentDocker.Tests.ServiceTests
       using (var container = _host.Create("postgres:9.6-alpine", false,
         new ContainerCreateParams
         {
-          PortMappings = new[] { "40001:5432" },
+          PublishAllPorts = true,
           Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" }
         }))
       {
@@ -194,7 +194,7 @@ namespace Ductus.FluentDocker.Tests.ServiceTests
       using (var container = _host.Create("postgres:9.6-alpine", false,
         new ContainerCreateParams
         {
-          PortMappings = new[] { "40001:5432" },
+          PublishAllPorts = true,
           Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" }
         }))
       {
@@ -217,7 +217,7 @@ namespace Ductus.FluentDocker.Tests.ServiceTests
       using (var container = _host.Create("postgres:9.6-alpine", false,
         new ContainerCreateParams
         {
-          PortMappings = new[] { "40001:5432" },
+          PublishAllPorts = true,
           Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" }
         }))
       {
@@ -250,7 +250,7 @@ namespace Ductus.FluentDocker.Tests.ServiceTests
       using (var container = _host.Create("postgres:9.6-alpine", false,
         new ContainerCreateParams
         {
-          PortMappings = new[] { "40001:5432" },
+          PublishAllPorts = true,
           Environment = new[] { "POSTGRES_PASSWORD=mysecretpassword" }
         }))
       {


### PR DESCRIPTION
If your test runner is configured to run several tests in parallel you will end up with bind errors because the port 40001 is already in use by another test.
> Ductus.FluentDocker.Common.FluentDockerException: Failed to start container modest_ramanujan log: Error response from daemon: driver failed programming external connectivity on endpoint modest_ramanujan (3e80ba4d0e93156184a77c573fe0b743c8e52cd590f3d58e0e4b6c9cc65cca3c): Bind for 0.0.0.0:40001 failed: port is already allocated

Also remove `ExposePort(40001, 5432)` in `PauseAndResumeShallWorkOnSingleContainer` where port mapping doesn't matter for the the test but could interfere with the `ExplicitPortMappingShouldWork` test.