### PR TITLE
Pass throwOnError: true when calling container.Export in unit tests

### DIFF
--- a/Ductus.FluentDocker.Tests/ServiceTests/ContainerServiceBasicTests.cs
+++ b/Ductus.FluentDocker.Tests/ServiceTests/ContainerServiceBasicTests.cs
@@ -232,7 +232,7 @@ namespace Ductus.FluentDocker.Tests.ServiceTests
 
         try
         {
-          var path = container.Export(fullPath);
+          var path = container.Export(fullPath, throwOnError: true);
           Assert.IsNotNull(path);
           Assert.IsTrue(File.Exists(fullPath));
         }
@@ -265,7 +265,7 @@ namespace Ductus.FluentDocker.Tests.ServiceTests
 
         try
         {
-          container.Export(fullPath, true);
+          container.Export(fullPath, explode: true, throwOnError: true);
           Assert.IsTrue(Directory.Exists(fullPath));
 
           var files = Directory.GetFiles(fullPath).ToArray();


### PR DESCRIPTION
Without it the `ExportRunningContainerExploadedShallSucceed` test would fail (Assert.IsTrue failed) but hides the actual cause of the error:
```
Ductus.FluentDocker.Common.FluentDockerException: Exception while un-taring archive ---> SharpCompress.Common.ExtractionException: Entry is a symbolic link but ExtractionOptions.WriteSymbolicLink delegate is null
   at SharpCompress.Common.ExtractionMethods.WriteEntryToFile(IEntry entry, String destinationFileName, ExtractionOptions options, Action`2 openAndWrite)
   at SharpCompress.Readers.IReaderExtensions.WriteEntryToFile(IReader reader, String destinationFileName, ExtractionOptions options)
   at SharpCompress.Common.ExtractionMethods.WriteEntryToDirectory(IEntry entry, String destinationDirectory, ExtractionOptions options, Action`2 write)
   at SharpCompress.Readers.IReaderExtensions.WriteEntryToDirectory(IReader reader, String destinationDirectory, ExtractionOptions options)
   at Ductus.FluentDocker.Extensions.CompressionExtensions.UnTar(String file, String destPath) in Ductus.FluentDocker/Extensions/CompressionExtensions.cs:line 19
   at Ductus.FluentDocker.Services.Extensions.ContainerExtensions.Export(IContainerService service, TemplateString fqPath, Boolean explode, Boolean throwOnError) in Ductus.FluentDocker/Services/Extensions/ContainerExtensions.cs:line 125
--- End of inner exception stack trace ---
    at Ductus.FluentDocker.Services.Extensions.ContainerExtensions.Export(IContainerService service, TemplateString fqPath, Boolean explode, Boolean throwOnError) in Ductus.FluentDocker/Services/Extensions/ContainerExtensions.cs:line 133
   at Ductus.FluentDocker.Tests.ServiceTests.ContainerServiceBasicTests.ExportRunningContainerExploadedShallSucceed() in Ductus.FluentDocker.Tests/ServiceTests/ContainerServiceBasicTests.cs:line 268
```