### PR TITLE
Simplify projects

### DIFF
--- a/Ductus.FluentDocker.MsTest/Ductus.FluentDocker.MsTest.csproj
+++ b/Ductus.FluentDocker.MsTest/Ductus.FluentDocker.MsTest.csproj
@@ -1,12 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netcoreapp1.1;netcoreapp2.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
-
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(DefineConstants);COREFX</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(DefineConstants);COREFX</DefineConstants>
-
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net461</TargetFrameworks>
     <Version>1.0.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
@@ -34,8 +29,6 @@ Documentation: https://github.com/mariotoffia/FluentDocker
 
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="5.3.7" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
   </ItemGroup>
   <ItemGroup>

--- a/Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj
+++ b/Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj
@@ -1,30 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netcoreapp2.0;netcoreapp3.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">$(DefineConstants);COREFX</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(DefineConstants);COREFX</DefineConstants>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="Moq" Version="4.16.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
-    <PackageReference Include="Npgsql" Version="4.0.7" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Npgsql" Version="5.0.7" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Ductus.FluentDocker\Ductus.FluentDocker.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ductus.FluentDocker.Tests/ExtensionTests/ResourceExtensionsTests.cs
+++ b/Ductus.FluentDocker.Tests/ExtensionTests/ResourceExtensionsTests.cs
@@ -5,7 +5,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ductus.FluentDocker.Tests.ExtensionTests
 {
-#if !COREFX
   [TestClass]
   public class ResourceExtensionsTests
   {
@@ -33,5 +32,4 @@ namespace Ductus.FluentDocker.Tests.ExtensionTests
       Assert.AreEqual("docker-compose.yml", res[0].Resource);
     }
   }
-#endif
 }

--- a/Ductus.FluentDocker/Common/FdOs.cs
+++ b/Ductus.FluentDocker/Common/FdOs.cs
@@ -1,15 +1,9 @@
-﻿#if COREFX
-using System.Runtime.InteropServices;
-#else
-using System;
-#endif
+﻿using System.Runtime.InteropServices;
 
 namespace Ductus.FluentDocker.Common
 {
   public static class FdOs
   {
-
-#if COREFX
 		public static bool IsWindows()
 			=> RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
@@ -18,16 +12,5 @@ namespace Ductus.FluentDocker.Common
 
 		public static bool IsLinux()
 			=> RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-#else
-    public static bool IsWindows()
-      => Environment.OSVersion.Platform != PlatformID.MacOSX &&
-         Environment.OSVersion.Platform != PlatformID.Unix;
-
-    public static bool IsOsx()
-      => Environment.OSVersion.Platform == PlatformID.MacOSX;
-
-    public static bool IsLinux()
-      => Environment.OSVersion.Platform == PlatformID.Unix;
-#endif
   }
 }

--- a/Ductus.FluentDocker/Ductus.FluentDocker.csproj
+++ b/Ductus.FluentDocker/Ductus.FluentDocker.csproj
@@ -1,13 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' != 'Unix' ">netstandard1.6;netstandard2.0;netstandard2.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Unix' ">netstandard1.6;netstandard2.0;netstandard2.1</TargetFrameworks>
-    
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(DefineConstants);COREFX</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);COREFX</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netstandard2.1' ">$(DefineConstants);COREFX</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFramework)' == '' ">$(DefineConstants);COREFX</DefineConstants>
-
+    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <Version>1.0.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
@@ -35,42 +28,19 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="5.3.7" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="SharpCompress" Version="0.23.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-      <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/Ductus.FluentDocker/Executors/ProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/ProcessExecutor.cs
@@ -46,7 +46,7 @@ namespace Ductus.FluentDocker.Executors
       if (0 != Env.Count)
         foreach (var key in Env.Keys)
         {
-#if COREFX
+#if NETSTANDARD1_6
           startInfo.Environment[key] = Env[key];
 #else
           startInfo.EnvironmentVariables[key] = Env[key];

--- a/Ductus.FluentDocker/Extensions/ResourceExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/ResourceExtensions.cs
@@ -97,7 +97,7 @@ namespace Ductus.FluentDocker.Extensions
 
     private static Assembly GetAssembly(string assemblyName)
     {
-#if COREFX
+#if NETSTANDARD1_6
       return GetAssemblies().First(x => x.GetName().Name == assemblyName);
 		}
 

--- a/Ductus.FluentDocker/Resources/ResourceQuery.cs
+++ b/Ductus.FluentDocker/Resources/ResourceQuery.cs
@@ -33,7 +33,7 @@ namespace Ductus.FluentDocker.Resources
 
     public IEnumerable<ResourceInfo> Query()
     {
-#if COREFX
+#if NETSTANDARD1_6
 			if (string.IsNullOrWhiteSpace(_assembly))
 				// TODO : Consider rework of Fluent API
 				throw new InvalidOperationException($"It is not possible to execute {nameof(Query)} without first executing {nameof(From)}.");

--- a/global.json
+++ b/global.json
@@ -1,5 +1,8 @@
 {
+  "$schema": "https://json.schemastore.org/global",
   "sdk": {
-    "version": "3.1.402"
+    "version": "5.0.200",
+    "allowPrerelease": false,
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
* Use the .NET 5 SDK (updated in global.json)
* Define the target frameworks only once, without condition on the operating system. Now that the [Microsoft.NETFramework.ReferenceAssemblies package](https://github.com/dotnet/sdk/issues/4009) is automatically referenced by the .NET SDK, the project builds fine also on Linux and macOS.
* Remove the `COREFX` constant, use appropriate constants already defined by the SDK (NETSTANDARD1_6) where needed.
* Update all test dependencies to their latest versions
* Simplify the package dependencies, only include what's actually needed. Note that absolutely _no_ package references are needed for .NET Standard 2.0 and 2.1

Dropping support for .NET Standard 1.6 will be easy:
1. Search for the three occurrences of `#if NETSTANDARD1_6` and delete the code
2. Remove `netstandard1.6` in the target frameworks
3. Remove the whole `<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">`