### PR TITLE
Cleanup old target frameworks

### DIFF
--- a/Ductus.FluentDocker.MsTest/Ductus.FluentDocker.MsTest.csproj
+++ b/Ductus.FluentDocker.MsTest/Ductus.FluentDocker.MsTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <Version>1.0.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
@@ -29,7 +29,7 @@ Documentation: https://github.com/mariotoffia/FluentDocker
 
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="5.3.7" PrivateAssets="All" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.17" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ductus.FluentDocker\Ductus.FluentDocker.csproj" />

--- a/Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj
+++ b/Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bot .NET Core 1 and .NET Core 2 have [reached end of support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core). The following warnings were displayed when compiling:
> Microsoft.NET.EolTargetFrameworks.targets(28, 5): [NETSDK1138] The target framework 'netcoreapp1.1' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.
> Microsoft.NET.EolTargetFrameworks.targets(28, 5): [NETSDK1138] The target framework 'netcoreapp2.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.

* Replace netcoreapp1.1 + netcoreapp2.0 with netstandard1.6 in Ductus.FluentDocker.MsTest. This required to bump MSTest.TestFramework to version 1.1.17 which is the first version to support .NET Standard.

* Replace netcoreapp2.0 with net5.0 in Ductus.FluentDocker.Tests