### PR TITLE
Use GetHostEntry instead of GetHostEntryAsync

### DIFF
--- a/Ductus.FluentDocker/Extensions/CommandExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/CommandExtensions.cs
@@ -165,7 +165,11 @@ namespace Ductus.FluentDocker.Extensions
     {
       try
       {
+#if NETSTANDARD1_6
         Dns.GetHostEntryAsync("host.docker.internal").Wait();
+#else
+        Dns.GetHostEntry("host.docker.internal");
+#endif
         return true;
       }
       catch (AggregateException ex)
@@ -185,7 +189,11 @@ namespace Ductus.FluentDocker.Extensions
       if (useCache && null != _cachedDockerIpAddress)
         return _cachedDockerIpAddress;
 
+#if NETSTANDARD1_6
       var hostEntry = Dns.GetHostEntryAsync("host.docker.internal").Result;
+#else
+      var hostEntry = Dns.GetHostEntry("host.docker.internal");
+#endif
       if (hostEntry.AddressList.Length > 0)
       {
         // Prefer IPv4 addresses


### PR DESCRIPTION
The parent methods (IsDockerDnsAvailable and EmulatedNativeAddress) are both synchronous methods, so better use the sync version of GetHostEntry to avoid all the problems that will be caused by the [sync over async](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#avoid-using-taskresult-and-taskwait) pattern.