### PR TITLE
GetImages bug

### DIFF
--- a/Ductus.FluentDocker/Commands/Client.cs
+++ b/Ductus.FluentDocker/Commands/Client.cs
@@ -105,7 +105,7 @@ namespace Ductus.FluentDocker.Commands
       var options = "--quiet --no-trunc --format \"{{.ID}};{{.Repository}};{{.Tag}}\"";
       if (!string.IsNullOrEmpty(filter))
       {
-        options = $" --filter=\"{filter}\"";
+        options += $" --filter=\"{filter}\"";
       }
 
       return


### PR DESCRIPTION
The GetImages command do not work when a filter has been passed since it will overwrite the base switches.

This closes Issue #219 