### PR TITLE
Split `usinga` into `using` and `a`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # FluentDocker
 
-This library enables `docker` and `docker-compose` interactions usinga _Fluent API_. It is supported on Linux, Windows and Mac. It also has support for the legazy `docker-machine` interactions.
+This library enables `docker` and `docker-compose` interactions using a _Fluent API_. It is supported on Linux, Windows and Mac. It also has support for the legazy `docker-machine` interactions.
 
 **Sample Fluent API usage**
 ```cs


### PR DESCRIPTION
I just noticed the combined words `using` and `a` while reading the README and wanted to help out by submitting a PR to split them.