### PR TITLE
Add ssh support to DockerUri

### DIFF
--- a/Ductus.FluentDocker/Model/Common/DockerUri.cs
+++ b/Ductus.FluentDocker/Model/Common/DockerUri.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Ductus.FluentDocker.Common;
 using Ductus.FluentDocker.Extensions;
 
@@ -33,11 +33,15 @@ namespace Ductus.FluentDocker.Model.Common
 
     public override string ToString()
     {
-      if (Scheme != "npipe")
-        return base.ToString();
+      var baseString = base.ToString();
 
-      var s = base.ToString();
-      return s.Substring(0, 6) + "//" + s.Substring(6);
+      if (Scheme == "ssh")
+        return baseString.TrimEnd('/');
+
+      if (Scheme == "npipe")
+        return baseString.Substring(0, 6) + "//" + baseString.Substring(6);
+
+      return baseString;
     }
   }
 }


### PR DESCRIPTION
I get errors when trying to connect to remote docker host over ssh.
```csharp
var service = new Builder()
                .UseHost().FromUri(new DockerUri("ssh://user@docker-host.com"))
                .UseContainer()
                .UseCompose()
                .FromFile("docker-compose.yml")
                .Build()
                .Start();
```
Errors have the following description:
```
Could not create composite service with file(s) docker-compose.yml - result: [27372] Failed to execute script docker-compose
Traceback (most recent call last):
  File "docker-compose", line 3, in <module>
  File "compose\cli\main.py", line 67, in main
  File "compose\cli\main.py", line 123, in perform_command
  File "compose\cli\command.py", line 58, in project_from_options
  File "compose\cli\docker_client.py", line 30, in make_context
  File "site-packages\docker\context\context.py", line 34, in __init__
  File "site-packages\docker\context\config.py", line 77, in get_context_host
  File "site-packages\docker\utils\utils.py", line 264, in parse_host
docker.errors.DockerException: Invalid bind address format: no path allowed for this protocol: ssh://user@docker-host.com/
```
Second example:
```csharp
var uri = new DockerUri("ssh://user@docker-host.com");
var hosts = new Hosts().FromUri(uri, "remote", true);
var v = hosts.Host.Version();
```
```
ssh host connection is not valid: extra path after the host: "/"
```
I think docker doesn't support ssh uri at the end with / and I have prepared a small fix.
