### PR TITLE
Remove .NET Standard 1.6 code

### DIFF
--- a/Ductus.FluentDocker/Ductus.FluentDocker.csproj
+++ b/Ductus.FluentDocker/Ductus.FluentDocker.csproj
@@ -41,13 +41,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/Ductus.FluentDocker/Executors/ProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/ProcessExecutor.cs
@@ -46,11 +46,7 @@ namespace Ductus.FluentDocker.Executors
       if (0 != Env.Count)
         foreach (var key in Env.Keys)
         {
-#if NETSTANDARD1_6
-          startInfo.Environment[key] = Env[key];
-#else
           startInfo.EnvironmentVariables[key] = Env[key];
-#endif
         }
 
       Logger.Log($"cmd: {_command} - arg: {_arguments}");

--- a/Ductus.FluentDocker/Extensions/CommandExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/CommandExtensions.cs
@@ -161,20 +161,6 @@ namespace Ductus.FluentDocker.Extensions
     }
 
 
-#if NETSTANDARD1_6
-    public static bool IsDockerDnsAvailable()
-    {
-      try
-      {
-        Dns.GetHostEntryAsync("host.docker.internal").Wait();
-        return true;
-      }
-      catch (Exception ex) when (ex.GetBaseException() is SocketException)
-      {
-        return false;
-      }
-    }
-#else
     public static bool IsDockerDnsAvailable()
     {
       try
@@ -187,7 +173,6 @@ namespace Ductus.FluentDocker.Extensions
         return false;
       }
     }
-#endif
 
     public static bool IsNative()
     {
@@ -199,11 +184,7 @@ namespace Ductus.FluentDocker.Extensions
       if (useCache && null != _cachedDockerIpAddress)
         return _cachedDockerIpAddress;
 
-#if NETSTANDARD1_6
-      var hostEntry = Dns.GetHostEntryAsync("host.docker.internal").Result;
-#else
       var hostEntry = Dns.GetHostEntry("host.docker.internal");
-#endif
       if (hostEntry.AddressList.Length > 0)
       {
         // Prefer IPv4 addresses

--- a/Ductus.FluentDocker/Extensions/ResourceExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/ResourceExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using Ductus.FluentDocker.Model.Common;
 using Ductus.FluentDocker.Resources;
@@ -97,28 +96,7 @@ namespace Ductus.FluentDocker.Extensions
 
     private static Assembly GetAssembly(string assemblyName)
     {
-#if NETSTANDARD1_6
-      return GetAssemblies().First(x => x.GetName().Name == assemblyName);
-		}
-
-		internal static IEnumerable<Assembly> GetAssemblies()
-		{
-			foreach (var library in Microsoft.Extensions.DependencyModel.DependencyContext.Default.RuntimeLibraries)
-			{
-				Assembly assembly;
-				try
-				{
-					assembly = Assembly.Load(new AssemblyName(library.Name));
-				}
-				catch (FileNotFoundException)
-				{
-					continue;
-				}
-				yield return assembly;
-			}
-#else
       return AppDomain.CurrentDomain.GetAssemblies().First(x => x.GetName().Name == assemblyName);
-#endif
     }
   }
 }

--- a/Ductus.FluentDocker/Resources/ResourceQuery.cs
+++ b/Ductus.FluentDocker/Resources/ResourceQuery.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Ductus.FluentDocker.Extensions;
 
 namespace Ductus.FluentDocker.Resources
 {
@@ -33,18 +32,10 @@ namespace Ductus.FluentDocker.Resources
 
     public IEnumerable<ResourceInfo> Query()
     {
-#if NETSTANDARD1_6
-			if (string.IsNullOrWhiteSpace(_assembly))
-				// TODO : Consider rework of Fluent API
-				throw new InvalidOperationException($"It is not possible to execute {nameof(Query)} without first executing {nameof(From)}.");
-			var assembly = ResourceExtensions.GetAssemblies()
-				.First(x => x.GetName().Name.Equals(_assembly, StringComparison.OrdinalIgnoreCase));
-#else
       var assembly = string.IsNullOrEmpty(_assembly)
         ? Assembly.GetCallingAssembly() :
         AppDomain.CurrentDomain.GetAssemblies()
         .First(x => x.GetName().Name.Equals(_assembly, StringComparison.OrdinalIgnoreCase));
-#endif
 
       var q = assembly.GetManifestResourceNames();
 


### PR DESCRIPTION
Now that .NET Standard 1.6 target framework is removed, all the .NET Standard 1.6 specific code can be deleted.

Also remove all unnecessary package references which are actually part of .NET Standard 2.0 and Microsoft.Extensions.DependencyModel which was only used in the .NET Standard 1.6 specific code.