### PR TITLE
Support for custom named Dockerfiles

### DIFF
--- a/Ductus.FluentDocker/Builders/FileBuilder.cs
+++ b/Ductus.FluentDocker/Builders/FileBuilder.cs
@@ -149,7 +149,7 @@ namespace Ductus.FluentDocker.Builders
     /// <param name="dest">To directory.</param>
     /// <param name="chownUserAndGroup">Optional --chown user:group.</param>
     /// <param name="fromAlias">
-    /// Optional source location from earlier buildstage FROM ... AS alias. This will 
+    /// Optional source location from earlier buildstage FROM ... AS alias. This will
     /// generate --from=aliasname in the _COPY_ command and hence reference a earlier
     /// _FROM ... AS aliasname_ buildstep as source.
     /// </param>
@@ -331,7 +331,12 @@ namespace Ductus.FluentDocker.Builders
         Directory.CreateDirectory(workingFolder);
       }
 
-      var dockerFile = Path.Combine(workingFolder, "Dockerfile");
+      if (string.IsNullOrWhiteSpace(_parent.Config.Params.File))
+      {
+        _parent.Config.Params.File = "Dockerfile";
+      }
+
+      var dockerFile = Path.Combine(workingFolder, _parent.Config.Params.File);
 
       var contents = !string.IsNullOrEmpty(_config.UseFile) ?
         _config.UseFile.FromFile() :


### PR DESCRIPTION
Possible fix for #246 based on my suggestion.

This fix exposes the `ImageBuilderConfig` field internally to make it possible to write a custom `ImageBuilderConfig.File` value.

Input is gladly received, I don't know if this is the correct way to achieve a solution for #246.