### PR TITLE
Support IPvlan networks

### DIFF
--- a/Ductus.FluentDocker/Model/Networks/NetworkType.cs
+++ b/Ductus.FluentDocker/Model/Networks/NetworkType.cs
@@ -6,6 +6,7 @@ namespace Ductus.FluentDocker.Model.Networks
     Bridge,
     Host,
     Overlay,
+    Ipvlan,
     Macvlan,
     None,
     Custom


### PR DESCRIPTION
This PR adds the IPvlan NetworkType (https://docs.docker.com/network/#network-drivers). I have an IPvlan network setup which trigger the following error:
```
Unhandled exception. System.ArgumentException: Requested value 'ipvlan' was not found.
   at System.Enum.TryParseByName(RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, UInt64& result)
   at System.Enum.TryParseInt32Enum(RuntimeType enumType, ReadOnlySpan`1 value, Int32 minInclusive, Int32 maxInclusive, Boolean ignoreCase, Boolean throwOnFailure, TypeCode type, Int32& result)
   at System.Enum.TryParse(Type enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, Object& result)
   at System.Enum.Parse(Type enumType, String value, Boolean ignoreCase)
   at Ductus.FluentDocker.Executors.Mappers.FdEventStreamMapper.CreateNetworkEvent(String action, String scope, String id, DateTime ts, JObject attributes)
   at Ductus.FluentDocker.Executors.Mappers.FdEventStreamMapper.Create(JObject obj)
   at Ductus.FluentDocker.Executors.Mappers.FdEventStreamMapper.OnData(String data, Boolean isStdErr)
   at Ductus.FluentDocker.Executors.ConsoleStream`1.<.ctor>b__4_0(Object sender, DataReceivedEventArgs args)
   at System.Diagnostics.Process.OutputReadNotifyUser(String data)
   at System.Diagnostics.AsyncStreamReader.FlushMessageQueue(Boolean rethrowInNewThread)
--- End of stack trace from previous location ---
   at System.Diagnostics.AsyncStreamReader.<>c.<FlushMessageQueue>b__18_0(Object edi)
   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
   at System.Threading.Thread.StartCallback()
```