### PR TITLE
Fixes and improvements to ExposeCommand

### DIFF
--- a/Ductus.FluentDocker/Model/Builders/FileBuilder/ExposeCommand.cs
+++ b/Ductus.FluentDocker/Model/Builders/FileBuilder/ExposeCommand.cs
@@ -1,19 +1,21 @@
-﻿using Ductus.FluentDocker.Model.Common;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Ductus.FluentDocker.Model.Builders.FileBuilder
 {
   public sealed class ExposeCommand : ICommand
   {
     public ExposeCommand(params int[] ports)
-    {
-      Ports = null == ports ? new int[0] : ports;
-    }
+      => Ports = ports.Select(p => p.ToString()) ?? Enumerable.Empty<string>();
 
-    public int[] Ports { get; }
+    public ExposeCommand(params string[] ports)
+      => Ports = ports ?? Enumerable.Empty<string>();
+
+    public IEnumerable<string> Ports { get; }
 
     public override string ToString()
     {
-      return $"EXPOSE {string.Join(",", Ports)}";
+      return $"EXPOSE {string.Join(" ", Ports)}";
     }
   }
 }


### PR DESCRIPTION
According to Docker [documentation](https://docs.docker.com/engine/reference/builder/) EXPOSE command is delimited by spaces and not by commas and it's template looks like so: `EXPOSE <port> [<port>/<protocol>...]` This also means that a protocol can be provided so the ExposeCommand should also accept a string as input.
