### PR TITLE
Update target frameworks

### DIFF
--- a/Ductus.FluentDocker.MsTest/Ductus.FluentDocker.MsTest.csproj
+++ b/Ductus.FluentDocker.MsTest/Ductus.FluentDocker.MsTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Version>1.0.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
@@ -31,12 +31,12 @@ Documentation: https://github.com/mariotoffia/FluentDocker
   <ItemGroup Condition="'$(Configuration)'=='Release'">
     <PackageReference Include="GitVersionTask" Version="5.3.7" PrivateAssets="All" />
   </ItemGroup>
- 
+
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
-  <ItemGroup>    
+  <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="1.1.17" />
   </ItemGroup>
   <ItemGroup>

--- a/Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj
+++ b/Ductus.FluentDocker.Tests/Ductus.FluentDocker.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ductus.FluentDocker/Ductus.FluentDocker.csproj
+++ b/Ductus.FluentDocker/Ductus.FluentDocker.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net462</TargetFrameworks>
     <Version>1.0.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
@@ -31,12 +31,12 @@
   <ItemGroup Condition="'$(Configuration)'=='Release'">
     <PackageReference Include="GitVersionTask" Version="5.3.7" PrivateAssets="All" />
   </ItemGroup>
- 
+
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
-  <ItemGroup>    
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/global",
   "sdk": {
-    "version": "5.0.200",
+    "version": "6.0.400",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }


### PR DESCRIPTION
.NET Core 3.1, .NET 5.0 and .NET Framework 4.6.1 are all out of support now

Replace them with .NET 6 (LTS) which will be supported [until November 12, 2024][1] and .NET Framework 4.6.2 which will be supported [until Jan 12, 2027][2]

Also drop .NET Standard 2.1 in favor of .NET 6.0 in the `Ductus.FluentDocker` project. The additional .NET Standard 2.1 target framework was not bringing anything substantial over .NET Standard 2.0. The .NET 6.0 at least will be beneficial for [string interpolation][3]. See also [Are there benefits in producing a .NET 6.0 version of a .NET Standard 2.0 library?][4] on Stack Overflow.

[1]: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle
[2]: https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-framework
[3]: https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/#arrays-strings-spans
[4]: https://stackoverflow.com/questions/70778797/are-there-benefits-in-producing-a-net-6-0-version-of-a-net-standard-2-0-librar/72266562#72266562
