### PR TITLE
Fix: Quotes around docker compose project directory argument + UTF8 docker logs

### DIFF
--- a/Ductus.FluentDocker/Commands/Compose.cs
+++ b/Ductus.FluentDocker/Commands/Compose.cs
@@ -544,7 +544,7 @@ namespace Ductus.FluentDocker.Commands
 
       if (!string.IsNullOrEmpty(ca.ProjectDirectory))
       {
-        composeArgs += $" --project-directory {ca.ProjectDirectory.Rendered}";
+        composeArgs += $" --project-directory \"{ca.ProjectDirectory.Rendered}\"";
       }
 
       var options = ca.NoStart ? "--no-start" : "--detach";
@@ -603,7 +603,7 @@ namespace Ductus.FluentDocker.Commands
             args += $" -f \"{cf}\"";
 
       if (!string.IsNullOrEmpty(altProjectName))
-        args += $" -p {altProjectName}";
+        args += $" -p \"{altProjectName}\"";
 
       var options = string.Empty;
       options += " -f"; // Don't ask to confirm removal
@@ -639,7 +639,7 @@ namespace Ductus.FluentDocker.Commands
             args += $" -f \"{cf}\"";
 
       if (!string.IsNullOrEmpty(altProjectName))
-        args += $" -p {altProjectName}";
+        args += $" -p \"{altProjectName}\"";
 
       var options = string.Empty;
       if (null != services && 0 != services.Length)
@@ -676,7 +676,7 @@ namespace Ductus.FluentDocker.Commands
             args += $" -f \"{cf}\"";
 
       if (!string.IsNullOrEmpty(commandArgs.AltProjectName))
-        args += $" -p {commandArgs.AltProjectName}";
+        args += $" -p \"{commandArgs.AltProjectName}\"";
 
       var options = string.Empty;
       if (commandArgs.DownloadAllTagged)

--- a/Ductus.FluentDocker/Executors/AsyncProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/AsyncProcessExecutor.cs
@@ -1,8 +1,9 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Ductus.FluentDocker.Common;
+using Ductus.FluentDocker.Extensions;
 using Ductus.FluentDocker.Model.Containers;
 
 namespace Ductus.FluentDocker.Executors
@@ -18,6 +19,7 @@ namespace Ductus.FluentDocker.Executors
       _command = command;
       _arguments = arguments;
       _workingdir = workingdir;
+      CommandExtensions.FixSudoCommand(command, arguments, out _command, out _arguments);
     }
 
     public Task<CommandResponse<TE>> Execute(CancellationToken cancellationToken = default(CancellationToken))

--- a/Ductus.FluentDocker/Executors/ProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/ProcessExecutor.cs
@@ -16,16 +16,9 @@ namespace Ductus.FluentDocker.Executors
     public ProcessExecutor(string command, string arguments, string workingdir = null)
     {
       _workingdir = workingdir;
-      if (command.StartsWith("echo") || command.StartsWith("sudo"))
-      {
-        _command = CommandExtensions.DefaultShell;
-        _arguments = $"-c \"{command} {arguments}\"";
-
-        return;
-      }
-
       _command = command;
       _arguments = arguments;
+      CommandExtensions.FixSudoCommand(command, arguments, out _command, out _arguments);
     }
 
     public IDictionary<string, string> Env { get; } = new Dictionary<string, string>();

--- a/Ductus.FluentDocker/Executors/StreamProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/StreamProcessExecutor.cs
@@ -30,7 +30,9 @@ namespace Ductus.FluentDocker.Executors
         UseShellExecute = false,
         Arguments = _arguments,
         FileName = _command,
-        WorkingDirectory = _workingdir
+        WorkingDirectory = _workingdir,
+        StandardErrorEncoding = System.Text.Encoding.UTF8,
+        StandardOutputEncoding = System.Text.Encoding.UTF8,
       }, new T(), token);
     }
   }

--- a/Ductus.FluentDocker/Executors/StreamProcessExecutor.cs
+++ b/Ductus.FluentDocker/Executors/StreamProcessExecutor.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Threading;
 using Ductus.FluentDocker.Common;
+using Ductus.FluentDocker.Extensions;
 
 namespace Ductus.FluentDocker.Executors
 {
@@ -16,6 +17,7 @@ namespace Ductus.FluentDocker.Executors
       _command = command;
       _arguments = arguments;
       _workingdir = workingdir;
+      CommandExtensions.FixSudoCommand(command, arguments, out _command, out _arguments);
     }
 
     public ConsoleStream<TE> Execute(CancellationToken token = default)

--- a/Ductus.FluentDocker/Extensions/CommandExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/CommandExtensions.cs
@@ -83,6 +83,21 @@ namespace Ductus.FluentDocker.Extensions
       _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword);
     }
 
+    public static void FixSudoCommand(string command, string arguments, out string fixedCommand, out string fixedArguments)
+    {
+      if (command.StartsWith("echo") || command.StartsWith("sudo"))
+      {
+        fixedCommand = CommandExtensions.DefaultShell;
+        string escapedArguments = arguments.Replace("\"", "\"\\\"\"");
+        fixedArguments = $"-c \"{command} {escapedArguments}\"";
+      }
+      else
+      {
+        fixedCommand = command;
+        fixedArguments = arguments;
+      }
+    }
+
     public static string ResolveBinary(this string dockerCommand, bool preferMachine = false, bool forceResolve = false)
     {
       if (forceResolve || null == _binaryResolver)

--- a/Ductus.FluentDocker/Services/Extensions/ContainerExtensions.cs
+++ b/Ductus.FluentDocker/Services/Extensions/ContainerExtensions.cs
@@ -23,10 +23,10 @@ namespace Ductus.FluentDocker.Services.Extensions
     /// <param name="follow">If continuous logs is wanted.</param>
     /// <param name="token">The cancellation token for logs, especially needed when <paramref name="follow" /> is set to true.</param>
     /// <returns>A console stream to consume.</returns>
-    public static ConsoleStream<string> Logs(this IContainerService service, bool follow = false,
+    public static ConsoleStream<string> Logs(this IContainerService service, bool follow = false, bool showTimeStamps = false,
       CancellationToken token = default)
     {
-      return service.DockerHost.Logs(service.Id, token, follow);
+      return service.DockerHost.Logs(service.Id, token, follow, showTimeStamps);
     }
 
     /// <summary>


### PR DESCRIPTION
Small fixes:
- Make sure docker logs are UTF8
- Make sure docker compose --project-directory argument has quotes around it. If the path had spaces, it broke.
- Also added quoting to project name, not sure if that one can contain spaces.
- Added showTimeStamps parameter in container Logs extension method.
- Bug in which 'sudo docker' was supplied as command to be executed to Executor classes that didn't proper handle that. 