### PR TITLE
Podman Support

### DIFF
--- a/Ductus.FluentDocker.Tests/ExtensionTests/ContainerEngineTests.cs
+++ b/Ductus.FluentDocker.Tests/ExtensionTests/ContainerEngineTests.cs
@@ -252,10 +252,9 @@ namespace Ductus.FluentDocker.Tests.ExtensionTests
     public void IsComposeBinaryPresentShallCheckBothV1AndV2()
     {
       // This should work regardless of engine
-      var isPresent = CommandExtensions.IsComposeBinaryPresent();
-      
       // Just verify it doesn't throw - actual result depends on environment
-      Assert.IsTrue(isPresent || !isPresent); // Always true, just checking it doesn't throw
+      var isPresent = CommandExtensions.IsComposeBinaryPresent();
+      // Method call above verifies it doesn't throw - no assertion needed
     }
 
     [TestMethod]

--- a/Ductus.FluentDocker.Tests/ExtensionTests/ContainerEngineTests.cs
+++ b/Ductus.FluentDocker.Tests/ExtensionTests/ContainerEngineTests.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Linq;
+using Ductus.FluentDocker.Commands;
+using Ductus.FluentDocker.Common;
+using Ductus.FluentDocker.Extensions;
+using Ductus.FluentDocker.Extensions.Utils;
+using Ductus.FluentDocker.Model.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ductus.FluentDocker.Tests.ExtensionTests
+{
+  [TestClass]
+  public class ContainerEngineTests
+  {
+    [TestInitialize]
+    public void Initialize()
+    {
+      // Reset to Auto for each test
+      ContainerEngine.Auto.SetContainerEngine();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+      // Reset to Auto after each test
+      ContainerEngine.Auto.SetContainerEngine();
+    }
+
+    [TestMethod]
+    public void SetContainerEngineShallUpdatePreference()
+    {
+      // Test Docker
+      ContainerEngine.Docker.SetContainerEngine();
+      Assert.AreEqual(ContainerEngine.Docker, CommandExtensions.ContainerEngine);
+
+      // Test Podman
+      ContainerEngine.Podman.SetContainerEngine();
+      Assert.AreEqual(ContainerEngine.Podman, CommandExtensions.ContainerEngine);
+
+      // Test Auto
+      ContainerEngine.Auto.SetContainerEngine();
+      Assert.AreEqual(ContainerEngine.Auto, CommandExtensions.ContainerEngine);
+    }
+
+    [TestMethod]
+    public void ActiveContainerEngineShallReflectResolvedEngine()
+    {
+      var resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Auto);
+      
+      // ActiveEngine should reflect what was actually found
+      Assert.IsNotNull(resolver.ActiveEngine);
+      Assert.IsTrue(resolver.ActiveEngine == ContainerEngine.Docker || resolver.ActiveEngine == ContainerEngine.Podman);
+      
+      // ActiveContainerEngine should match
+      var activeEngine = CommandExtensions.ActiveContainerEngine;
+      Assert.IsTrue(activeEngine == ContainerEngine.Docker || activeEngine == ContainerEngine.Podman);
+    }
+
+    [TestMethod]
+    public void PreferredEngineShallBeStored()
+    {
+      var resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Podman);
+      Assert.AreEqual(ContainerEngine.Podman, resolver.PreferredEngine);
+
+      resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Docker);
+      Assert.AreEqual(ContainerEngine.Docker, resolver.PreferredEngine);
+
+      resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Auto);
+      Assert.AreEqual(ContainerEngine.Auto, resolver.PreferredEngine);
+    }
+
+    [TestMethod]
+    public void ResolverShallPreferDockerWhenAutoAndBothAvailable()
+    {
+      // This test verifies that when Auto is selected and both engines are available,
+      // Docker is preferred. Note: This may not always be testable depending on environment.
+      var resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Auto);
+      
+      if (resolver.MainDockerClient != null)
+      {
+        // If Docker is available, it should be selected
+        Assert.AreEqual(ContainerEngine.Docker, resolver.ActiveEngine);
+      }
+    }
+
+    [TestMethod]
+    public void ResolverShallUsePodmanWhenExplicitlyRequested()
+    {
+      var resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Podman);
+      
+      // If Podman is available, it should be selected
+      if (resolver.MainDockerClient != null && resolver.MainDockerClient.Engine == ContainerEngine.Podman)
+      {
+        Assert.AreEqual(ContainerEngine.Podman, resolver.ActiveEngine);
+        Assert.IsTrue(resolver.MainDockerClient.Binary.Contains("podman", StringComparison.OrdinalIgnoreCase));
+      }
+    }
+
+    [TestMethod]
+    public void ResolverShallUseDockerWhenExplicitlyRequested()
+    {
+      var resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Docker);
+      
+      // If Docker is available, it should be selected
+      if (resolver.MainDockerClient != null && resolver.MainDockerClient.Engine == ContainerEngine.Docker)
+      {
+        Assert.AreEqual(ContainerEngine.Docker, resolver.ActiveEngine);
+        Assert.IsTrue(resolver.MainDockerClient.Binary.Contains("docker", StringComparison.OrdinalIgnoreCase));
+      }
+    }
+
+    [TestMethod]
+    public void DockerBinaryShallIdentifyEngineCorrectly()
+    {
+      // Test through resolver - DockerBinary constructor is internal
+      var resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Auto);
+      
+      // Check that binaries have correct engine identification
+      foreach (var binary in resolver.Binaries)
+      {
+        if (binary.Binary.Contains("docker", StringComparison.OrdinalIgnoreCase) && 
+            !binary.Binary.Contains("podman", StringComparison.OrdinalIgnoreCase))
+        {
+          Assert.AreEqual(ContainerEngine.Docker, binary.Engine, 
+            $"Binary {binary.Binary} should be identified as Docker");
+        }
+        else if (binary.Binary.Contains("podman", StringComparison.OrdinalIgnoreCase))
+        {
+          Assert.AreEqual(ContainerEngine.Podman, binary.Engine, 
+            $"Binary {binary.Binary} should be identified as Podman");
+        }
+      }
+    }
+
+    [TestMethod]
+    public void ResolveBinaryShallNormalizePodmanCommands()
+    {
+      var resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Auto);
+      
+      // These should all resolve to the same binary type
+      try
+      {
+        var dockerCmd = "docker".ResolveBinary(resolver);
+        var podmanCmd = "podman".ResolveBinary(resolver);
+        
+        // Both should resolve (though to potentially different binaries)
+        Assert.IsNotNull(dockerCmd);
+        Assert.IsNotNull(podmanCmd);
+      }
+      catch (FluentDockerException)
+      {
+        // If neither is available, that's ok for this test
+      }
+    }
+
+    [TestMethod]
+    public void ResolveBinaryShallNormalizeComposeCommands()
+    {
+      var resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Auto);
+      
+      try
+      {
+        var dockerComposeCmd = "docker-compose".ResolveBinary(resolver);
+        var podmanComposeCmd = "podman-compose".ResolveBinary(resolver);
+        
+        // Both should resolve (though to potentially different binaries)
+        Assert.IsNotNull(dockerComposeCmd);
+        Assert.IsNotNull(podmanComposeCmd);
+      }
+      catch (FluentDockerException)
+      {
+        // If neither is available, that's ok for this test
+      }
+    }
+
+    [TestMethod]
+    public void InfoSwitchShallHandlePodmanGracefully()
+    {
+      // Save current engine
+      var originalEngine = CommandExtensions.ContainerEngine;
+      
+      try
+      {
+        // Set to Podman
+        ContainerEngine.Podman.SetContainerEngine();
+        
+        // Switch should return success with informative message
+        var dockerUri = new DockerUri(DockerUri.GetDockerHostEnvironmentPathOrDefault());
+        var result = dockerUri.Switch();
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(result.Data.Contains("Podman", StringComparison.OrdinalIgnoreCase) || 
+                     (result.Log.Count > 0 && result.Log[0].Contains("Podman", StringComparison.OrdinalIgnoreCase)));
+      }
+      finally
+      {
+        // Restore original engine
+        originalEngine.SetContainerEngine();
+      }
+    }
+
+    [TestMethod]
+    public void InfoLinuxDaemonShallHandlePodmanGracefully()
+    {
+      // Save current engine
+      var originalEngine = CommandExtensions.ContainerEngine;
+      
+      try
+      {
+        // Set to Podman
+        ContainerEngine.Podman.SetContainerEngine();
+        
+        // LinuxDaemon should return success with informative message
+        var dockerUri = new DockerUri(DockerUri.GetDockerHostEnvironmentPathOrDefault());
+        var result = dockerUri.LinuxDaemon();
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(result.Data.Contains("Podman", StringComparison.OrdinalIgnoreCase) || 
+                     (result.Log.Count > 0 && result.Log[0].Contains("Podman", StringComparison.OrdinalIgnoreCase)));
+      }
+      finally
+      {
+        // Restore original engine
+        originalEngine.SetContainerEngine();
+      }
+    }
+
+    [TestMethod]
+    public void InfoWindowsDaemonShallReturnErrorForPodman()
+    {
+      // Save current engine
+      var originalEngine = CommandExtensions.ContainerEngine;
+      
+      try
+      {
+        // Set to Podman
+        ContainerEngine.Podman.SetContainerEngine();
+        
+        // WindowsDaemon should return error for Podman
+        var dockerUri = new DockerUri(DockerUri.GetDockerHostEnvironmentPathOrDefault());
+        var result = dockerUri.WindowsDaemon();
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(result.Error.Contains("Podman", StringComparison.OrdinalIgnoreCase) ||
+                     result.Error.Contains("Windows", StringComparison.OrdinalIgnoreCase));
+      }
+      finally
+      {
+        // Restore original engine
+        originalEngine.SetContainerEngine();
+      }
+    }
+
+    [TestMethod]
+    public void IsComposeBinaryPresentShallCheckBothV1AndV2()
+    {
+      // This should work regardless of engine
+      var isPresent = CommandExtensions.IsComposeBinaryPresent();
+      
+      // Just verify it doesn't throw - actual result depends on environment
+      Assert.IsTrue(isPresent || !isPresent); // Always true, just checking it doesn't throw
+    }
+
+    [TestMethod]
+    public void GetResolvedBinariesShallIncludeEngineInfo()
+    {
+      var binaries = CommandExtensions.GetResolvedBinaries();
+      
+      Assert.IsNotNull(binaries);
+      Assert.IsTrue(binaries.Any());
+      
+      // Should include engine information
+      var engineInfo = string.Join(" ", binaries);
+      Assert.IsTrue(engineInfo.Contains("engine", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public void ResolverShallFallbackToAvailableEngineWhenPreferredNotAvailable()
+    {
+      // Test with explicit Podman when only Docker might be available
+      try
+      {
+        var resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Podman);
+        
+        // If Podman is not available but Docker is, it should still work (fallback behavior)
+        // The resolver will throw if NO engine is available, but if one is available, it should use it
+        if (resolver.MainDockerClient != null)
+        {
+          // An engine was found (might be Docker or Podman)
+          Assert.IsNotNull(resolver.ActiveEngine);
+        }
+      }
+      catch (FluentDockerException)
+      {
+        // If no engine is available at all, that's expected
+      }
+    }
+
+    [TestMethod]
+    public void ComposeV2DetectionShallWorkWithPodman()
+    {
+      var resolver = new DockerBinariesResolver(SudoMechanism.None, null, ContainerEngine.Podman);
+      
+      // If Podman is available and supports Compose V2, it should be detected
+      if (resolver.MainDockerClient != null && resolver.MainDockerClient.Engine == ContainerEngine.Podman)
+      {
+        // Compose V2 might be available
+        // Just verify the check doesn't throw
+        var hasV2 = resolver.IsDockerComposeV2Available;
+        Assert.IsTrue(hasV2 || !hasV2); // Always true, just checking it doesn't throw
+      }
+    }
+  }
+}

--- a/Ductus.FluentDocker/Commands/ClientStreams.cs
+++ b/Ductus.FluentDocker/Commands/ClientStreams.cs
@@ -29,7 +29,12 @@ namespace Ductus.FluentDocker.Commands
         options += $" --since {since}";
       }
 
-      options += numLines.HasValue ? $" --tail={numLines}" : " --tail=all";
+      // Only add --tail if a specific number is requested
+      // Omitting --tail shows all logs by default (works with both Docker and Podman)
+      if (numLines.HasValue)
+      {
+        options += $" --tail={numLines}";
+      }
 
       if (showTimeStamps)
       {

--- a/Ductus.FluentDocker/Commands/ComposeStreams.cs
+++ b/Ductus.FluentDocker/Commands/ComposeStreams.cs
@@ -38,7 +38,12 @@ namespace Ductus.FluentDocker.Commands
         options += $" --since {since}";
       }
 
-      options += numLines.HasValue ? $" --tail={numLines}" : " --tail=all";
+      // Only add --tail if a specific number is requested
+      // Omitting --tail shows all logs by default (works with both Docker and Podman)
+      if (numLines.HasValue)
+      {
+        options += $" --tail={numLines}";
+      }
 
       if (showTimeStamps)
       {

--- a/Ductus.FluentDocker/Commands/Info.cs
+++ b/Ductus.FluentDocker/Commands/Info.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using Ductus.FluentDocker.Common;
 using Ductus.FluentDocker.Executors;
 using Ductus.FluentDocker.Executors.Parsers;
 using Ductus.FluentDocker.Extensions;
@@ -40,25 +42,62 @@ namespace Ductus.FluentDocker.Commands
 
     public static CommandResponse<string> Switch(this DockerUri host, ICertificatePaths certificates = null)
     {
-      var args = $"{host.RenderBaseArgs(certificates)}";
+      // dockercli is Docker Desktop for Windows specific - not available with Podman
+      if (CommandExtensions.ActiveContainerEngine == ContainerEngine.Podman)
+      {
+        return new CommandResponse<string>(true, new List<string> { "Podman does not support daemon switching" }, "", "Podman does not support daemon switching");
+      }
 
-      return new ProcessExecutor<NoLineResponseParser, string>(
-        "dockercli".ResolveBinary(), $"{args} -SwitchDaemon").Execute();
+      try
+      {
+        var args = $"{host.RenderBaseArgs(certificates)}";
+        return new ProcessExecutor<NoLineResponseParser, string>(
+          "dockercli".ResolveBinary(), $"{args} -SwitchDaemon").Execute();
+      }
+      catch (FluentDockerException ex) when (ex.Message.Contains("dockercli"))
+      {
+        return new CommandResponse<string>(false, new List<string>(), "dockercli binary not found - this is only available with Docker Desktop for Windows", default(string));
+      }
     }
 
     public static CommandResponse<string> LinuxDaemon(this DockerUri host, ICertificatePaths certificates = null)
     {
-      var args = $"{host.RenderBaseArgs(certificates)}";
+      // dockercli is Docker Desktop for Windows specific - not available with Podman
+      if (CommandExtensions.ActiveContainerEngine == ContainerEngine.Podman)
+      {
+        return new CommandResponse<string>(true, new List<string> { "Podman always uses Linux containers" }, "", "Podman always uses Linux containers");
+      }
 
-      return new ProcessExecutor<NoLineResponseParser, string>(
-        "dockercli".ResolveBinary(), $"{args} -SwitchLinuxEngine").Execute();
+      try
+      {
+        var args = $"{host.RenderBaseArgs(certificates)}";
+        return new ProcessExecutor<NoLineResponseParser, string>(
+          "dockercli".ResolveBinary(), $"{args} -SwitchLinuxEngine").Execute();
+      }
+      catch (FluentDockerException ex) when (ex.Message.Contains("dockercli"))
+      {
+        return new CommandResponse<string>(false, new List<string>(), "dockercli binary not found - this is only available with Docker Desktop for Windows", default(string));
+      }
     }
+    
     public static CommandResponse<string> WindowsDaemon(this DockerUri host, ICertificatePaths certificates = null)
     {
-      var args = $"{host.RenderBaseArgs(certificates)}";
+      // dockercli is Docker Desktop for Windows specific - not available with Podman
+      if (CommandExtensions.ActiveContainerEngine == ContainerEngine.Podman)
+      {
+        return new CommandResponse<string>(false, new List<string>(), "Podman does not support Windows containers", default(string));
+      }
 
-      return new ProcessExecutor<NoLineResponseParser, string>(
-        "dockercli".ResolveBinary(), $"{args} -SwitchWindowsEngine").Execute();
+      try
+      {
+        var args = $"{host.RenderBaseArgs(certificates)}";
+        return new ProcessExecutor<NoLineResponseParser, string>(
+          "dockercli".ResolveBinary(), $"{args} -SwitchWindowsEngine").Execute();
+      }
+      catch (FluentDockerException ex) when (ex.Message.Contains("dockercli"))
+      {
+        return new CommandResponse<string>(false, new List<string>(), "dockercli binary not found - this is only available with Docker Desktop for Windows", default(string));
+      }
     }
   }
 }

--- a/Ductus.FluentDocker/Commands/Info.cs
+++ b/Ductus.FluentDocker/Commands/Info.cs
@@ -54,7 +54,7 @@ namespace Ductus.FluentDocker.Commands
         return new ProcessExecutor<NoLineResponseParser, string>(
           "dockercli".ResolveBinary(), $"{args} -SwitchDaemon").Execute();
       }
-      catch (FluentDockerException ex) when (ex.Message.Contains("dockercli"))
+      catch (FluentDockerException ex) when (ex.Message.Contains("Could not resolve binary") && ex.Message.Contains("dockercli"))
       {
         return new CommandResponse<string>(false, new List<string>(), "dockercli binary not found - this is only available with Docker Desktop for Windows", default(string));
       }
@@ -74,7 +74,7 @@ namespace Ductus.FluentDocker.Commands
         return new ProcessExecutor<NoLineResponseParser, string>(
           "dockercli".ResolveBinary(), $"{args} -SwitchLinuxEngine").Execute();
       }
-      catch (FluentDockerException ex) when (ex.Message.Contains("dockercli"))
+      catch (FluentDockerException ex) when (ex.Message.Contains("Could not resolve binary") && ex.Message.Contains("dockercli"))
       {
         return new CommandResponse<string>(false, new List<string>(), "dockercli binary not found - this is only available with Docker Desktop for Windows", default(string));
       }
@@ -94,7 +94,7 @@ namespace Ductus.FluentDocker.Commands
         return new ProcessExecutor<NoLineResponseParser, string>(
           "dockercli".ResolveBinary(), $"{args} -SwitchWindowsEngine").Execute();
       }
-      catch (FluentDockerException ex) when (ex.Message.Contains("dockercli"))
+      catch (FluentDockerException ex) when (ex.Message.Contains("Could not resolve binary") && ex.Message.Contains("dockercli"))
       {
         return new CommandResponse<string>(false, new List<string>(), "dockercli binary not found - this is only available with Docker Desktop for Windows", default(string));
       }

--- a/Ductus.FluentDocker/Executors/Mappers/FdEventStreamMapper.cs
+++ b/Ductus.FluentDocker/Executors/Mappers/FdEventStreamMapper.cs
@@ -13,10 +13,22 @@ namespace Ductus.FluentDocker.Executors.Mappers
 
     public FdEvent OnData(string data, bool isStdErr)
     {
-      if (null == data)
+      if (string.IsNullOrWhiteSpace(data))
         return null;
 
-      return Create(JObject.Parse(data));
+      try
+      {
+        return Create(JObject.Parse(data));
+      }
+      catch (Exception ex) when (ex is Newtonsoft.Json.JsonReaderException || 
+                                  ex is ArgumentNullException ||
+                                  ex is NullReferenceException ||
+                                  ex is FormatException)
+      {
+        // Skip events that cannot be parsed or have unexpected format
+        // This handles differences between Docker and Podman event formats
+        return null;
+      }
     }
 
     public FdEvent OnProcessEnd(int exitCode)
@@ -32,14 +44,18 @@ namespace Ductus.FluentDocker.Executors.Mappers
       if (null == obj)
         return null;
 
-      // Get header
-      var action = obj["Action"].Value<string>();
-      var type = obj["Type"].Value<string>();
-      var scope = obj["scope"].Value<string>();
-      var actor = (JObject)obj["Actor"];
-      var attributes = (JObject)actor["Attributes"];
-      var id = actor["ID"].Value<string>();
-      var timeNano = obj["timeNano"].Value<long>();
+      // Get header - use null-safe access for compatibility with different container engines
+      var action = obj["Action"]?.Value<string>() ?? obj["action"]?.Value<string>();
+      var type = obj["Type"]?.Value<string>() ?? obj["type"]?.Value<string>();
+      var scope = obj["scope"]?.Value<string>() ?? "local";
+      var actor = obj["Actor"] as JObject ?? obj["actor"] as JObject;
+      var attributes = actor?["Attributes"] as JObject ?? actor?["attributes"] as JObject ?? new JObject();
+      var id = actor?["ID"]?.Value<string>() ?? actor?["id"]?.Value<string>() ?? string.Empty;
+      var timeNano = obj["timeNano"]?.Value<long>() ?? obj["timenano"]?.Value<long>() ?? 0;
+
+      // Return null if we couldn't parse essential fields
+      if (string.IsNullOrEmpty(action) || string.IsNullOrEmpty(type))
+        return null;
 
       var ts = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddTicks(timeNano / 100).ToLocalTime();
 
@@ -75,8 +91,8 @@ namespace Ductus.FluentDocker.Executors.Mappers
             EventActor = new ContainerStartEvent.ContainerStartActor
             {
               Id = id,
-              Name = attributes["name"].Value<string>(),
-              Image = attributes["image"].Value<string>(),
+              Name = GetString(attributes, "name"),
+              Image = GetString(attributes, "image"),
               Labels = GetExtraInfo(attributes, new[] { "name", "image" })
             }
           };
@@ -88,8 +104,8 @@ namespace Ductus.FluentDocker.Executors.Mappers
             EventActor = new ContainerCreateEvent.ContainerCreateActor
             {
               Id = id,
-              Name = attributes["name"].Value<string>(),
-              Image = attributes["image"].Value<string>(),
+              Name = GetString(attributes, "name"),
+              Image = GetString(attributes, "image"),
               Labels = GetExtraInfo(attributes, new[] { "name", "image" })
             }
           };
@@ -101,9 +117,9 @@ namespace Ductus.FluentDocker.Executors.Mappers
             EventActor = new ContainerKillEvent.ContainerKillActor
             {
               Id = id,
-              Name = attributes["name"].Value<string>(),
-              Image = attributes["image"].Value<string>(),
-              Signal = attributes["signal"].Value<string>(),
+              Name = GetString(attributes, "name"),
+              Image = GetString(attributes, "image"),
+              Signal = GetString(attributes, "signal"),
               Labels = GetExtraInfo(attributes, new[] { "name", "image", "signal" })
             }
           };
@@ -115,9 +131,9 @@ namespace Ductus.FluentDocker.Executors.Mappers
             EventActor = new ContainerDieEvent.ContainerDieActor
             {
               Id = id,
-              Name = attributes["name"].Value<string>(),
-              Image = attributes["image"].Value<string>(),
-              ExitCode = attributes["exitCode"].Value<string>(),
+              Name = GetString(attributes, "name"),
+              Image = GetString(attributes, "image"),
+              ExitCode = GetString(attributes, "exitCode"),
               Labels = GetExtraInfo(attributes, new[] { "name", "image", "exitCode" })
             }
           };
@@ -129,8 +145,8 @@ namespace Ductus.FluentDocker.Executors.Mappers
             EventActor = new ContainerStopEvent.ContainerStopActor
             {
               Id = id,
-              Name = attributes["name"].Value<string>(),
-              Image = attributes["image"].Value<string>(),
+              Name = GetString(attributes, "name"),
+              Image = GetString(attributes, "image"),
               Labels = GetExtraInfo(attributes, new[] { "name", "image" })
             }
           };
@@ -142,8 +158,8 @@ namespace Ductus.FluentDocker.Executors.Mappers
             EventActor = new ContainerDestroyEvent.ContainerDestroyActor
             {
               Id = id,
-              Name = attributes["name"].Value<string>(),
-              Image = attributes["image"].Value<string>(),
+              Name = GetString(attributes, "name"),
+              Image = GetString(attributes, "image"),
               Labels = GetExtraInfo(attributes, new[] { "name", "image" })
             }
           };
@@ -157,6 +173,7 @@ namespace Ductus.FluentDocker.Executors.Mappers
       switch (action)
       {
         case "connect":
+          var connectType = GetString(attributes, "type");
           return new NetworkConnectEvent
           {
             Scope = EventScope.Local,
@@ -164,13 +181,14 @@ namespace Ductus.FluentDocker.Executors.Mappers
             EventActor = new NetworkConnectEvent.NetworkConnectActor
             {
               Id = id,
-              ContainerId = attributes["container"].Value<string>(),
-              Name = attributes["name"].Value<string>(),
-              Type = (NetworkType)Enum.Parse(typeof(NetworkType), attributes["type"].Value<string>(), true/*ignoreCase*/),
+              ContainerId = GetString(attributes, "container"),
+              Name = GetString(attributes, "name"),
+              Type = ParseNetworkType(connectType),
               Labels = GetExtraInfo(attributes, new[] { "container", "name", "type" })
             }
           };
         case "disconnect":
+          var disconnectType = GetString(attributes, "type");
           return new NetworkDisconnectEvent
           {
             Scope = EventScope.Local,
@@ -178,15 +196,23 @@ namespace Ductus.FluentDocker.Executors.Mappers
             EventActor = new NetworkDisconnectEvent.NetworkDisconnectActor
             {
               Id = id,
-              ContainerId = attributes["container"].Value<string>(),
-              Name = attributes["name"].Value<string>(),
-              Type = (NetworkType)Enum.Parse(typeof(NetworkType), attributes["type"].Value<string>(), true/*ignoreCase*/),
+              ContainerId = GetString(attributes, "container"),
+              Name = GetString(attributes, "name"),
+              Type = ParseNetworkType(disconnectType),
               Labels = GetExtraInfo(attributes, new[] { "container", "name", "type" })
             }
           };
       }
 
       return null;
+    }
+
+    private static NetworkType ParseNetworkType(string type)
+    {
+      if (string.IsNullOrEmpty(type))
+        return NetworkType.Bridge;
+      
+      return Enum.TryParse<NetworkType>(type, true, out var result) ? result : NetworkType.Bridge;
     }
 
     private static FdEvent CreateImageEvent(string action, string scope, string id, DateTime ts, JObject attributes)
@@ -201,7 +227,7 @@ namespace Ductus.FluentDocker.Executors.Mappers
             EventActor = new ImagePullEvent.ImagePullActor
             {
               Id = id,
-              Name = attributes["name"].Value<string>(),
+              Name = GetString(attributes, "name"),
               Labels = GetExtraInfo(attributes, new[] { "name" })
             }
           };
@@ -228,11 +254,22 @@ namespace Ductus.FluentDocker.Executors.Mappers
     private static IList<Tuple<string, string>> GetExtraInfo(JObject obj, string[] nonlabels)
     {
       var list = new List<Tuple<string, string>>();
+      if (obj == null)
+        return list;
+        
       foreach (var prop in obj.Properties().Where(x => !nonlabels.Contains(x.Name)))
       {
-        list.Add(new Tuple<string, string>(prop.Name, prop.Value.ToString()));
+        list.Add(new Tuple<string, string>(prop.Name, prop.Value?.ToString() ?? string.Empty));
       }
       return list;
+    }
+
+    /// <summary>
+    /// Safely gets a string value from a JObject, returning empty string if not found.
+    /// </summary>
+    private static string GetString(JObject obj, string key)
+    {
+      return obj?[key]?.Value<string>() ?? string.Empty;
     }
   }
 }

--- a/Ductus.FluentDocker/Executors/Parsers/ClientContainerInspectCommandResponder.cs
+++ b/Ductus.FluentDocker/Executors/Parsers/ClientContainerInspectCommandResponder.cs
@@ -10,15 +10,21 @@ namespace Ductus.FluentDocker.Executors.Parsers
 
     public IProcessResponse<Container> Process(ProcessExecutionResult response)
     {
-      if (string.IsNullOrEmpty(response.StdOut))
+      if (response.ExitCode != 0)
       {
-        Response = response.ToResponse(false, "Empty response", new Container());
+        var errorMessage = !string.IsNullOrWhiteSpace(response.StdErr)
+          ? response.StdErr.Trim()
+          : $"Container inspect failed with exit code {response.ExitCode}";
+        Response = response.ToResponse<Container>(false, errorMessage, null);
         return this;
       }
 
-      if (response.ExitCode != 0)
+      if (string.IsNullOrEmpty(response.StdOut))
       {
-        Response = response.ToErrorResponse(new Container());
+        var errorMessage = !string.IsNullOrWhiteSpace(response.StdErr)
+          ? response.StdErr.Trim()
+          : "Empty response from container inspect";
+        Response = response.ToResponse<Container>(false, errorMessage, null);
         return this;
       }
 

--- a/Ductus.FluentDocker/Executors/Parsers/SingleStringResponseParser.cs
+++ b/Ductus.FluentDocker/Executors/Parsers/SingleStringResponseParser.cs
@@ -8,12 +8,27 @@ namespace Ductus.FluentDocker.Executors.Parsers
 
     public IProcessResponse<string> Process(ProcessExecutionResult response)
     {
+      // Check for command failure first
+      if (response.ExitCode != 0)
+      {
+        var errorMessage = !string.IsNullOrWhiteSpace(response.StdErr) 
+          ? response.StdErr.Trim() 
+          : $"Command failed with exit code {response.ExitCode}";
+        Response = response.ToResponse(false, errorMessage, string.Empty);
+        return this;
+      }
+
       var arr = response.StdOutAsArray;
+      if (arr.Length == 0)
+      {
+        var errorMessage = !string.IsNullOrWhiteSpace(response.StdErr)
+          ? response.StdErr.Trim()
+          : "No output received from command";
+        Response = response.ToResponse(false, errorMessage, string.Empty);
+        return this;
+      }
 
-      Response = arr.Length == 0
-        ? response.ToResponse(false, "No line", string.Empty)
-        : response.ToResponse(true, string.Empty, arr[0]);
-
+      Response = response.ToResponse(true, string.Empty, arr[0]);
       return this;
     }
   }

--- a/Ductus.FluentDocker/Extensions/CommandExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/CommandExtensions.cs
@@ -18,8 +18,9 @@ namespace Ductus.FluentDocker.Extensions
     private static SudoMechanism _sudoMechanism = SudoMechanism.None;
     private static string _sudoPassword;
     private static string _defaultShell = "bash";
+    private static ContainerEngine _containerEngine = ContainerEngine.Auto;
 
-    private static DockerBinariesResolver _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword);
+    private static DockerBinariesResolver _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword, _containerEngine);
 
     /// <summary>
     ///   Reads a <see cref="ConsoleStream{T}" /> until <see cref="ConsoleStream{T}.IsFinished" /> is set to true
@@ -70,7 +71,7 @@ namespace Ductus.FluentDocker.Extensions
     /// <exception cref="ArgumentException">If sudo mechanism password is wanted but no password was provided.</exception>
     /// <remarks>
     /// By default the library operates on SudoMechanism.None and therefore expects the current user to be able to
-    /// communicate with the docker daemon.
+    /// communicate with the container engine (Docker daemon or Podman).
     /// </remarks>
     [Experimental]
     public static void SetSudo(this SudoMechanism sudo, string password = null)
@@ -80,25 +81,60 @@ namespace Ductus.FluentDocker.Extensions
 
       _sudoMechanism = sudo;
       _sudoPassword = password;
-      _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword);
+      _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword, _containerEngine);
     }
+
+    /// <summary>
+    /// Sets the preferred container engine to use.
+    /// </summary>
+    /// <param name="engine">The container engine to use (Docker, Podman, or Auto).</param>
+    /// <remarks>
+    /// By default the library operates with ContainerEngine.Auto which will prefer Docker if available,
+    /// falling back to Podman if Docker is not found.
+    /// 
+    /// Call this method early in your application startup to configure which container engine to use:
+    /// <code>
+    /// ContainerEngine.Podman.SetContainerEngine();
+    /// </code>
+    /// </remarks>
+    public static void SetContainerEngine(this ContainerEngine engine)
+    {
+      _containerEngine = engine;
+      _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword, _containerEngine);
+    }
+
+    /// <summary>
+    /// Gets the currently configured container engine preference.
+    /// </summary>
+    public static ContainerEngine ContainerEngine => _containerEngine;
+
+    /// <summary>
+    /// Gets the actual container engine that is being used after binary resolution.
+    /// </summary>
+    /// <remarks>
+    /// This may differ from the configured preference if the preferred engine is not available.
+    /// For example, if ContainerEngine.Auto is set and only Podman is available, this will return Podman.
+    /// </remarks>
+    public static ContainerEngine ActiveContainerEngine => _binaryResolver?.ActiveEngine ?? ContainerEngine.Docker;
 
     public static string ResolveBinary(this string dockerCommand, bool preferMachine = false, bool forceResolve = false)
     {
       if (forceResolve || null == _binaryResolver)
-        _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword);
+        _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword, _containerEngine);
 
       return dockerCommand.ResolveBinary(_binaryResolver, preferMachine);
     }
 
     public static string ResolveBinary(this string dockerCommand, DockerBinariesResolver resolver, bool preferMachine = false)
     {
-      var binary = resolver.Resolve(dockerCommand, preferMachine);
+      // Normalize compose commands - treat "docker-compose" and "podman-compose" the same way
+      var normalizedCommand = NormalizeCommand(dockerCommand);
+      var binary = resolver.Resolve(normalizedCommand, preferMachine);
 
-      // Special handling for Docker Compose V2
-      if (binary.Type == DockerBinaryType.ComposeV2 && dockerCommand.Equals("docker-compose", StringComparison.OrdinalIgnoreCase))
+      // Special handling for Compose V2 (both Docker and Podman support 'compose' subcommand)
+      if (binary.Type == DockerBinaryType.ComposeV2 && IsComposeCommand(dockerCommand))
       {
-        // For V2, we need to return 'docker compose' instead of 'docker-compose'
+        // For V2, we need to return 'docker/podman compose' instead of 'docker-compose/podman-compose'
         if (FdOs.IsWindows() || binary.Sudo == SudoMechanism.None)
           return $"{binary.FqPath} compose";
         
@@ -114,28 +150,44 @@ namespace Ductus.FluentDocker.Extensions
       if (FdOs.IsWindows() || binary.Sudo == SudoMechanism.None)
         return binary.FqPath;
 
-      string cmd;
       if (binary.Sudo == SudoMechanism.NoPassword)
-        cmd = $"sudo {binary.FqPath}";
-      else
-        cmd = $"echo {binary.SudoPassword} | sudo -S {binary.FqPath}";
+        return $"sudo {binary.FqPath}";
+      
+      return $"echo {binary.SudoPassword} | sudo -S {binary.FqPath}";
+    }
 
-      if (string.IsNullOrEmpty(cmd))
+    /// <summary>
+    /// Normalizes command names to their canonical form for binary resolution.
+    /// </summary>
+    private static string NormalizeCommand(string command)
+    {
+      var lowerCommand = command?.ToLower();
+      
+      // Normalize Podman commands to their Docker equivalents for resolution
+      return lowerCommand switch
       {
-        if (!string.IsNullOrEmpty(dockerCommand) && dockerCommand.ToLower() == "docker-machine")
-          throw new FluentDockerException(
-            $"Could not find {dockerCommand} make sure it is on your path. From 2.2.0 you have to seprately install it via https://github.com/docker/machine/releases");
+        "podman" => "docker",
+        "podman.exe" => "docker",
+        "podman-compose" => "docker-compose",
+        "podman-compose.exe" => "docker-compose",
+        _ => command
+      };
+    }
 
-        throw new FluentDockerException($"Could not find {dockerCommand}, make sure it is on your path.");
-      }
-
-      return cmd;
+    /// <summary>
+    /// Checks if the command is a compose command (either docker-compose or podman-compose).
+    /// </summary>
+    private static bool IsComposeCommand(string command)
+    {
+      var lowerCommand = command?.ToLower();
+      return lowerCommand == "docker-compose" || lowerCommand == "docker-compose.exe" ||
+             lowerCommand == "podman-compose" || lowerCommand == "podman-compose.exe";
     }
 
     public static bool IsMachineBinaryPresent()
     {
       if (null == _binaryResolver)
-        _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword);
+        _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword, _containerEngine);
 
       return null != _binaryResolver.MainDockerMachine;
 
@@ -144,20 +196,19 @@ namespace Ductus.FluentDocker.Extensions
     public static bool IsComposeBinaryPresent()
     {
       if (null == _binaryResolver)
-        _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword);
+        _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword, _containerEngine);
 
-      return null != _binaryResolver.MainDockerCompose;
-
+      return null != _binaryResolver.MainDockerCompose || null != _binaryResolver.MainDockerComposeV2;
     }
 
     /// <summary>
-    /// Gets the detected Docker Compose version
+    /// Gets the detected Compose version (V1 or V2).
     /// </summary>
-    /// <returns>The detected Docker Compose version</returns>
+    /// <returns>The detected Compose version</returns>
     public static ComposeVersion DetectComposeVersion()
     {
       if (null == _binaryResolver)
-        _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword);
+        _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword, _containerEngine);
 
       return null != _binaryResolver.MainDockerComposeV2 ? ComposeVersion.V2 : ComposeVersion.V1;
     }
@@ -165,13 +216,16 @@ namespace Ductus.FluentDocker.Extensions
     public static IEnumerable<string> GetResolvedBinaries()
     {
       if (null == _binaryResolver)
-        _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword);
+        _binaryResolver = new DockerBinariesResolver(_sudoMechanism, _sudoPassword, _containerEngine);
 
+      var engineInfo = $"engine        : {_binaryResolver.ActiveEngine} (preferred: {_binaryResolver.PreferredEngine})";
+      
       return new List<string>
       {
-        "docker        : " + (_binaryResolver.MainDockerClient.FqPath ?? "not found"),
-        "docker-compose: " + (_binaryResolver.MainDockerCompose.FqPath ?? "not found"),
-        "docker-machine: " + (_binaryResolver.MainDockerMachine.FqPath ?? "not found")
+        engineInfo,
+        "client        : " + (_binaryResolver.MainDockerClient?.FqPath ?? "not found"),
+        "compose       : " + (_binaryResolver.MainDockerCompose?.FqPath ?? (_binaryResolver.MainDockerComposeV2?.FqPath + " (V2)") ?? "not found"),
+        "machine       : " + (_binaryResolver.MainDockerMachine?.FqPath ?? "not found")
       };
     }
 

--- a/Ductus.FluentDocker/Extensions/CommandExtensions.cs
+++ b/Ductus.FluentDocker/Extensions/CommandExtensions.cs
@@ -132,7 +132,7 @@ namespace Ductus.FluentDocker.Extensions
       var binary = resolver.Resolve(normalizedCommand, preferMachine);
 
       // Special handling for Compose V2 (both Docker and Podman support 'compose' subcommand)
-      if (binary.Type == DockerBinaryType.ComposeV2 && IsComposeCommand(dockerCommand))
+      if (binary.Type == DockerBinaryType.ComposeV2 && IsComposeCommand(normalizedCommand))
       {
         // For V2, we need to return 'docker/podman compose' instead of 'docker-compose/podman-compose'
         if (FdOs.IsWindows() || binary.Sudo == SudoMechanism.None)

--- a/Ductus.FluentDocker/Extensions/Utils/DockerBinariesResolver.cs
+++ b/Ductus.FluentDocker/Extensions/Utils/DockerBinariesResolver.cs
@@ -45,7 +45,7 @@ namespace Ductus.FluentDocker.Extensions.Utils
 
       if (null == MainDockerCompose && null == MainDockerComposeV2)
       {
-        var engineName = GetEngineName(ActiveEngine);
+        var engineName = GetEngineName(preferredEngine);
         Logger.Log($"Failed to find {engineName}-compose client binary (neither V1 nor V2) - please add it to your path");
       }
     }
@@ -54,24 +54,40 @@ namespace Ductus.FluentDocker.Extensions.Utils
     {
       var clients = Binaries.Where(x => !x.IsToolbox && x.Type == DockerBinaryType.DockerClient).ToList();
       
-      return preferredEngine switch
+      var selected = preferredEngine switch
       {
         ContainerEngine.Docker => clients.FirstOrDefault(x => x.Engine == ContainerEngine.Docker) ?? clients.FirstOrDefault(),
         ContainerEngine.Podman => clients.FirstOrDefault(x => x.Engine == ContainerEngine.Podman) ?? clients.FirstOrDefault(),
         _ => clients.FirstOrDefault(x => x.Engine == ContainerEngine.Docker) ?? clients.FirstOrDefault() // Auto: prefer Docker
       };
+      
+      // Log warning if preferred engine was explicitly requested but not available
+      if (selected != null && preferredEngine != ContainerEngine.Auto && selected.Engine != preferredEngine)
+      {
+        Logger.Log($"Warning: {GetEngineName(preferredEngine)} was requested but not available. Using {GetEngineName(selected.Engine)} instead.");
+      }
+      
+      return selected;
     }
 
     private DockerBinary SelectMainCompose(ContainerEngine preferredEngine)
     {
       var composes = Binaries.Where(x => !x.IsToolbox && x.Type == DockerBinaryType.Compose).ToList();
       
-      return preferredEngine switch
+      var selected = preferredEngine switch
       {
         ContainerEngine.Docker => composes.FirstOrDefault(x => x.Engine == ContainerEngine.Docker) ?? composes.FirstOrDefault(),
         ContainerEngine.Podman => composes.FirstOrDefault(x => x.Engine == ContainerEngine.Podman) ?? composes.FirstOrDefault(),
         _ => composes.FirstOrDefault(x => x.Engine == ContainerEngine.Docker) ?? composes.FirstOrDefault() // Auto: prefer Docker
       };
+      
+      // Log warning if preferred engine was explicitly requested but not available
+      if (selected != null && preferredEngine != ContainerEngine.Auto && selected.Engine != preferredEngine)
+      {
+        Logger.Log($"Warning: {GetEngineName(preferredEngine)}-compose was requested but not available. Using {GetEngineName(selected.Engine)}-compose instead.");
+      }
+      
+      return selected;
     }
 
     private static string GetEngineName(ContainerEngine engine)

--- a/Ductus.FluentDocker/Extensions/Utils/DockerBinariesResolver.cs
+++ b/Ductus.FluentDocker/Extensions/Utils/DockerBinariesResolver.cs
@@ -10,40 +10,78 @@ using static Ductus.FluentDocker.Common.FdOs;
 namespace Ductus.FluentDocker.Extensions.Utils
 {
   /// <summary>
-  ///   Resolves the available docker commands on the local machine.
+  ///   Resolves the available container engine commands on the local machine.
+  ///   Supports Docker, Podman, and other compatible container engines.
   /// </summary>
   public sealed class DockerBinariesResolver
   {
     public DockerBinariesResolver(SudoMechanism sudo, string password, params string[] paths)
+      : this(sudo, password, ContainerEngine.Auto, paths)
     {
-      Binaries = ResolveFromPaths(sudo, password, paths).ToArray();
-      MainDockerClient = Binaries.FirstOrDefault(x => !x.IsToolbox && x.Type == DockerBinaryType.DockerClient);
-      MainDockerCompose = Binaries.FirstOrDefault(x => !x.IsToolbox && x.Type == DockerBinaryType.Compose);
+    }
+
+    public DockerBinariesResolver(SudoMechanism sudo, string password, ContainerEngine preferredEngine, params string[] paths)
+    {
+      PreferredEngine = preferredEngine;
+      Binaries = ResolveFromPaths(sudo, password, preferredEngine, paths).ToArray();
+      
+      // Select the main client based on preferred engine
+      MainDockerClient = SelectMainClient(preferredEngine);
+      MainDockerCompose = SelectMainCompose(preferredEngine);
       MainDockerComposeV2 = CheckComposeV2(sudo, password);
       MainDockerMachine = Binaries.FirstOrDefault(x => !x.IsToolbox && x.Type == DockerBinaryType.Machine);
       MainDockerCli = Binaries.FirstOrDefault(x => !x.IsToolbox && x.Type == DockerBinaryType.Cli);
       HasToolbox = Binaries.Any(x => x.IsToolbox);
+      
+      // Determine the actual engine being used
+      ActiveEngine = MainDockerClient?.Engine ?? ContainerEngine.Docker;
 
       if (null == MainDockerClient)
       {
-        Logger.Log("Failed to find docker client binary - please add it to your path");
-        throw new FluentDockerException("Failed to find docker client binary - please add it to your path");
+        var engineName = GetEngineName(preferredEngine);
+        Logger.Log($"Failed to find {engineName} client binary - please add it to your path");
+        throw new FluentDockerException($"Failed to find {engineName} client binary - please add it to your path");
       }
 
       if (null == MainDockerCompose && null == MainDockerComposeV2)
       {
-        Logger.Log("Failed to find docker-compose client binary (neither V1 nor V2) - please add it to your path");
+        var engineName = GetEngineName(ActiveEngine);
+        Logger.Log($"Failed to find {engineName}-compose client binary (neither V1 nor V2) - please add it to your path");
       }
-/*
-      if (null == MainDockerMachine)
+    }
+
+    private DockerBinary SelectMainClient(ContainerEngine preferredEngine)
+    {
+      var clients = Binaries.Where(x => !x.IsToolbox && x.Type == DockerBinaryType.DockerClient).ToList();
+      
+      return preferredEngine switch
       {
-        Logger.Log(
-            "Failed to find docker-machine client binary - " +
-                   "If you need it: please add it to your path. If you're running docker " +
-                   "2.2.0 or later you have to install it using " +
-                   "https://github.com/docker/machine/releases");
-      }
-      */
+        ContainerEngine.Docker => clients.FirstOrDefault(x => x.Engine == ContainerEngine.Docker) ?? clients.FirstOrDefault(),
+        ContainerEngine.Podman => clients.FirstOrDefault(x => x.Engine == ContainerEngine.Podman) ?? clients.FirstOrDefault(),
+        _ => clients.FirstOrDefault(x => x.Engine == ContainerEngine.Docker) ?? clients.FirstOrDefault() // Auto: prefer Docker
+      };
+    }
+
+    private DockerBinary SelectMainCompose(ContainerEngine preferredEngine)
+    {
+      var composes = Binaries.Where(x => !x.IsToolbox && x.Type == DockerBinaryType.Compose).ToList();
+      
+      return preferredEngine switch
+      {
+        ContainerEngine.Docker => composes.FirstOrDefault(x => x.Engine == ContainerEngine.Docker) ?? composes.FirstOrDefault(),
+        ContainerEngine.Podman => composes.FirstOrDefault(x => x.Engine == ContainerEngine.Podman) ?? composes.FirstOrDefault(),
+        _ => composes.FirstOrDefault(x => x.Engine == ContainerEngine.Docker) ?? composes.FirstOrDefault() // Auto: prefer Docker
+      };
+    }
+
+    private static string GetEngineName(ContainerEngine engine)
+    {
+      return engine switch
+      {
+        ContainerEngine.Docker => "docker",
+        ContainerEngine.Podman => "podman",
+        _ => "container engine (docker/podman)"
+      };
     }
 
     public DockerBinary[] Binaries { get; }
@@ -55,6 +93,16 @@ namespace Ductus.FluentDocker.Extensions.Utils
     public bool IsDockerMachineAvailable => null != MainDockerMachine;
     public bool IsDockerComposeV2Available => null != MainDockerComposeV2;
     public bool HasToolbox { get; }
+    
+    /// <summary>
+    /// Gets the preferred container engine specified during construction.
+    /// </summary>
+    public ContainerEngine PreferredEngine { get; }
+    
+    /// <summary>
+    /// Gets the actual container engine that is being used.
+    /// </summary>
+    public ContainerEngine ActiveEngine { get; }
 
     public DockerBinary Resolve(string binary, bool preferMachine = false)
     {
@@ -85,7 +133,7 @@ namespace Ductus.FluentDocker.Extensions.Utils
       return resolved;
     }
 
-    private static IEnumerable<DockerBinary> ResolveFromPaths(SudoMechanism sudo, string password, params string[] paths)
+    private static IEnumerable<DockerBinary> ResolveFromPaths(SudoMechanism sudo, string password, ContainerEngine preferredEngine, params string[] paths)
     {
       var isWindows = IsWindows();
       if (null == paths || 0 == paths.Length)
@@ -117,32 +165,59 @@ namespace Ductus.FluentDocker.Extensions.Utils
 
           if (isWindows)
           {
-            list.AddRange(from file in Directory.GetFiles(path, "docker*.*")
-                          let f = Path.GetFileName(file.ToLower())
-                          where null != f && (f.Equals("docker.exe") || f.Equals("docker-compose.exe") ||
-                                              f.Equals("docker-machine.exe"))
-                          select new DockerBinary(path, f, sudo, password));
-
-            var dockercli = Path.GetFullPath(Path.Combine(path, "..\\.."));
-            if (File.Exists(Path.Combine(dockercli, "dockercli.exe")))
+            // Search for Docker binaries
+            if (preferredEngine == ContainerEngine.Auto || preferredEngine == ContainerEngine.Docker)
             {
-              list.Add(new DockerBinary(dockercli, "dockercli.exe", sudo, password));
+              list.AddRange(from file in Directory.GetFiles(path, "docker*.*")
+                            let f = Path.GetFileName(file.ToLower())
+                            where null != f && (f.Equals("docker.exe") || f.Equals("docker-compose.exe") ||
+                                                f.Equals("docker-machine.exe"))
+                            select new DockerBinary(path, f, sudo, password));
+
+              var dockercli = Path.GetFullPath(Path.Combine(path, "..\\.."));
+              if (File.Exists(Path.Combine(dockercli, "dockercli.exe")))
+              {
+                list.Add(new DockerBinary(dockercli, "dockercli.exe", sudo, password));
+              }
+            }
+
+            // Search for Podman binaries
+            if (preferredEngine == ContainerEngine.Auto || preferredEngine == ContainerEngine.Podman)
+            {
+              list.AddRange(from file in Directory.GetFiles(path, "podman*.*")
+                            let f = Path.GetFileName(file.ToLower())
+                            where null != f && (f.Equals("podman.exe") || f.Equals("podman-compose.exe"))
+                            select new DockerBinary(path, f, sudo, password));
             }
 
             continue;
           }
 
-          list.AddRange(from file in Directory.GetFiles(path, "docker*")
-                        let f = Path.GetFileName(file)
-                        let f2 = f.ToLower()
-                        where f2.Equals("docker") || f2.Equals("docker-compose") || f2.Equals("docker-machine")
-                        select new DockerBinary(path, f, sudo, password));
+          // Linux/macOS: Search for Docker binaries
+          if (preferredEngine == ContainerEngine.Auto || preferredEngine == ContainerEngine.Docker)
+          {
+            list.AddRange(from file in Directory.GetFiles(path, "docker*")
+                          let f = Path.GetFileName(file)
+                          let f2 = f.ToLower()
+                          where f2.Equals("docker") || f2.Equals("docker-compose") || f2.Equals("docker-machine")
+                          select new DockerBinary(path, f, sudo, password));
+          }
+
+          // Linux/macOS: Search for Podman binaries
+          if (preferredEngine == ContainerEngine.Auto || preferredEngine == ContainerEngine.Podman)
+          {
+            list.AddRange(from file in Directory.GetFiles(path, "podman*")
+                          let f = Path.GetFileName(file)
+                          let f2 = f.ToLower()
+                          where f2.Equals("podman") || f2.Equals("podman-compose")
+                          select new DockerBinary(path, f, sudo, password));
+          }
         }
         catch (Exception e)
         {
           // Illegal character in path if env variable PATH like this (spaces before ';'):
           // c:\folder1;c:\folder2;c:\folder3     ;
-          Logger.Log("Failed to get docker binary from path: " + path + Environment.NewLine + e);
+          Logger.Log("Failed to get container engine binary from path: " + path + Environment.NewLine + e);
         }
       }
       return list;
@@ -155,14 +230,14 @@ namespace Ductus.FluentDocker.Extensions.Utils
 
       try
       {
-        // Test if 'docker compose' command exists (V2 plugin)
+        // Test if 'compose' subcommand exists (V2 style - both Docker and Podman support this)
         var result = new ProcessExecutor<Executors.Parsers.StringListResponseParser, IList<string>>(
           MainDockerClient.FqPath,
           "compose version").Execute();
 
         if (result.Success)
         {
-          // Docker Compose V2 exists
+          // Compose V2 is available
           return new DockerBinary(
             System.IO.Path.GetDirectoryName(MainDockerClient.FqPath), 
             System.IO.Path.GetFileName(MainDockerClient.FqPath), 
@@ -174,7 +249,7 @@ namespace Ductus.FluentDocker.Extensions.Utils
       catch
       {
         // Compose V2 plugin is not available
-        Logger.Log("Docker Compose V2 plugin is not available");
+        Logger.Log("Compose V2 plugin is not available");
       }
       
       return null;

--- a/Ductus.FluentDocker/Extensions/Utils/DockerBinary.cs
+++ b/Ductus.FluentDocker/Extensions/Utils/DockerBinary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Ductus.FluentDocker.Model.Common;
 
 namespace Ductus.FluentDocker.Extensions.Utils
@@ -23,6 +23,7 @@ namespace Ductus.FluentDocker.Extensions.Utils
       Type = Translate(binary);
       Sudo = sudo;
       SudoPassword = password;
+      Engine = DetermineEngine(binary);
 
       var isToolbox = Environment.GetEnvironmentVariable("DOCKER_TOOLBOX_INSTALL_PATH")?.Equals(Path);
       IsToolbox = isToolbox ?? false;
@@ -35,6 +36,7 @@ namespace Ductus.FluentDocker.Extensions.Utils
       Type = type;
       Sudo = sudo;
       SudoPassword = password;
+      Engine = DetermineEngine(binary);
 
       var isToolbox = Environment.GetEnvironmentVariable("DOCKER_TOOLBOX_INSTALL_PATH")?.Equals(Path);
       IsToolbox = isToolbox ?? false;
@@ -46,19 +48,34 @@ namespace Ductus.FluentDocker.Extensions.Utils
       {
         case "docker":
         case "docker.exe":
+        case "podman":
+        case "podman.exe":
           return DockerBinaryType.DockerClient;
         case "docker-machine":
         case "docker-machine.exe":
           return DockerBinaryType.Machine;
         case "docker-compose":
         case "docker-compose.exe":
+        case "podman-compose":
+        case "podman-compose.exe":
           return DockerBinaryType.Compose;
         case "dockercli":
         case "dockercli.exe":
           return DockerBinaryType.Cli;
         default:
-          throw new Exception($"Cannot determine the docker type on binary {binary}");
+          throw new Exception($"Cannot determine the container engine type for binary {binary}");
       }
+    }
+
+    /// <summary>
+    /// Determines the container engine based on the binary name.
+    /// </summary>
+    private static ContainerEngine DetermineEngine(string binary)
+    {
+      var lowerBinary = binary.ToLower();
+      if (lowerBinary.StartsWith("podman"))
+        return ContainerEngine.Podman;
+      return ContainerEngine.Docker;
     }
 
     public string FqPath => System.IO.Path.Combine(Path, Binary);
@@ -68,5 +85,10 @@ namespace Ductus.FluentDocker.Extensions.Utils
     public bool IsToolbox { get; }
     public SudoMechanism Sudo { get; }
     public string SudoPassword { get; }
+    
+    /// <summary>
+    /// Gets the container engine this binary belongs to.
+    /// </summary>
+    public ContainerEngine Engine { get; }
   }
 }

--- a/Ductus.FluentDocker/Model/Common/ContainerEngine.cs
+++ b/Ductus.FluentDocker/Model/Common/ContainerEngine.cs
@@ -1,0 +1,29 @@
+namespace Ductus.FluentDocker.Model.Common
+{
+  /// <summary>
+  /// Specifies the container engine to use.
+  /// </summary>
+  /// <remarks>
+  /// This differs from <see cref="Ductus.FluentDocker.Model.Containers.ContainerRuntime"/> which specifies
+  /// the OCI runtime (like runc or nvidia) used by the container engine.
+  /// </remarks>
+  public enum ContainerEngine
+  {
+    /// <summary>
+    /// Automatically detect the available container engine.
+    /// Docker is preferred if both Docker and Podman are available.
+    /// </summary>
+    Auto = 0,
+
+    /// <summary>
+    /// Use Docker as the container engine.
+    /// </summary>
+    Docker = 1,
+
+    /// <summary>
+    /// Use Podman as the container engine.
+    /// Podman is an open-source, daemonless container engine that is a drop-in replacement for Docker.
+    /// </summary>
+    Podman = 2
+  }
+}

--- a/Ductus.FluentDocker/README.md
+++ b/Ductus.FluentDocker/README.md
@@ -5,7 +5,7 @@
 [![Downloads](https://img.shields.io/nuget/dt/Ductus.FluentDocker.svg)](https://www.nuget.org/packages/Ductus.FluentDocker)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This library enables `docker` and `docker-compose` interactions using a _Fluent API_. It is supported on Linux, Windows and Mac. It also has support for the legacy `docker-machine` interactions.
+This library enables `docker` and `docker-compose` interactions using a _Fluent API_. It is supported on Linux, Windows and Mac. It also has support for the legacy `docker-machine` interactions. The library supports both Docker and Podman as container engines. Configure the engine using `ContainerEngine.Podman.SetContainerEngine()`.
 
 **Have a look at the [project site](https://github.com/mariotoffia/FluentDocker) for more information.**
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # FluentDocker
 
-This library enables `docker` and `docker-compose` interactions usinga _Fluent API_. It is supported on Linux, Windows and Mac. It also has support for the legazy `docker-machine` interactions.
+This library enables `docker` and `docker-compose` interactions using a _Fluent API_. It is supported on Linux, Windows and Mac. It also has support for the legacy `docker-machine` interactions. The library supports both Docker and Podman as container engines. Podman is a daemonless, open-source container engine that is a drop-in replacement for Docker. See the [Container Engine Configuration](#container-engine-configuration) section below for details.
 
 **:bulb: Breaking changes. It will not adhere to `AssumeComposeVersion` instead it will autodetect if it supports `docker compose` subcommand and automatically set it to V2. If not supported, it will use `docker-compose` and this is V1.**
 
@@ -59,6 +59,32 @@ This fires up a postgres and waits for it to be ready. To use compose, just do i
 
 :bulb **Note for Linux Users:** Docker requires _sudo_ by default and the library by default expects that executing user do not
 need to do _sudo_ in order to talk to the docker daemon. More description can be found in the _Talking to Docker Daemon_ chapter.
+
+## Container Engine Configuration
+
+FluentDocker supports both Docker and Podman as container engines. By default, the library will automatically detect and prefer Docker if both are available. You can explicitly configure which engine to use:
+
+```cs
+using Ductus.FluentDocker.Model.Common;
+using Ductus.FluentDocker.Extensions;
+
+// Use Podman explicitly
+ContainerEngine.Podman.SetContainerEngine();
+
+// Or use Docker explicitly
+ContainerEngine.Docker.SetContainerEngine();
+
+// Or let it auto-detect (default - prefers Docker if available)
+ContainerEngine.Auto.SetContainerEngine();
+```
+
+**When to use Podman:**
+- You're on Windows and using Podman Desktop
+- You prefer a daemonless container engine
+- You need rootless containers
+- Docker is not available on your system
+
+**Note:** Podman is designed as a drop-in replacement for Docker, so all FluentDocker APIs work the same way regardless of which engine you choose. The library automatically handles the differences in binary names (`docker` vs `podman`, `docker-compose` vs `podman-compose`).
 
 The fluent _API_ builds up one or more services. Each service may be composite or singular. Therefore it is possible
 to e.g. fire up several _docker-compose_ based services and manage each of them as a single service or dig in and use
@@ -843,9 +869,12 @@ The above snippet fires up the wordpress docker compose project and checks the _
 (in this case "https://wordpress.org/"). If not it returns _500_ and the ```WaitForHttp``` function will wait 500 milliseconds before invoking again. This works for any custom
 lambda as well, just use ```WaitFor``` instead. Thus it is possible to e.g. query a database before continuing inside the using scope.
 
-## Talking to Docker Daemon
+## Talking to Container Engine Daemon
+
 For Linux and Mac users there are several options how to authenticate towards the socket. _FluentDocker_ supports no _sudo_, _sudo_ without any password (user added as NOPASSWD in /etc/sudoer), or
-_sudo_ with password. The default is that FluentDocker expects to be able to talk without any _sudo_. The options ar global but can be changed in runtime.
+_sudo_ with password. The default is that FluentDocker expects to be able to talk without any _sudo_. The options are global but can be changed in runtime.
+
+**Note:** If you're using Podman, it typically doesn't require sudo since it's designed to run rootless by default. Docker may require sudo depending on your system configuration.
 
 ```cs
      SudoMechanism.None.SetSudo(); // This is the default

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 
 # FluentDocker
-FluentDocker is a library to interact with docker-machine, docker-compose and docker. It supports the docker for windows, docker for mac, docker machine, and native linux (however only limited tests on Linux and Mac). 
+FluentDocker is a library to interact with docker-machine, docker-compose and docker. It supports the docker for windows, docker for mac, docker machine, and native linux (however only limited tests on Linux and Mac). The library supports both Docker and Podman as container engines. Podman is a daemonless, open-source container engine that is a drop-in replacement for Docker. See the [Container Engine Configuration](#container-engine-configuration) section below for details. 
 This library is available at nuget [Ductus.FluentDocker](https://www.nuget.org/packages/Ductus.FluentDocker/ "Nuget Home for Ductus.FluentDocker") 
 and the ms test support is available at [Ductus.FluentDocker.MsTest](https://www.nuget.org/packages/Ductus.FluentDocker.MsTest/ "Nuget Home for Ductus.FluentDocker.MsTest").
 
@@ -51,11 +51,39 @@ This fires up a postgres and waits for it to be ready. To use compose, just do i
 
 The site http://mariotoffia.github.io/FluentDocker/ is under construction but will have a _"1.0"_ release before christmas.
 
+## Container Engine Configuration
+
+FluentDocker supports both Docker and Podman as container engines. By default, the library will automatically detect and prefer Docker if both are available. You can explicitly configure which engine to use:
+
+```cs
+using Ductus.FluentDocker.Model.Common;
+using Ductus.FluentDocker.Extensions;
+
+// Use Podman explicitly
+ContainerEngine.Podman.SetContainerEngine();
+
+// Or use Docker explicitly
+ContainerEngine.Docker.SetContainerEngine();
+
+// Or let it auto-detect (default - prefers Docker if available)
+ContainerEngine.Auto.SetContainerEngine();
+```
+
+**When to use Podman:**
+- You're on Windows and using Podman Desktop
+- You prefer a daemonless container engine
+- You need rootless containers
+- Docker is not available on your system
+
+**Note:** Podman is designed as a drop-in replacement for Docker, so all FluentDocker APIs work the same way regardless of which engine you choose. The library automatically handles the differences in binary names (`docker` vs `podman`, `docker-compose` vs `podman-compose`).
+
 **Note for Linux Users:** _Docker requires _sudo_ by default and the library by default expects that executing user do not
 need to do _sudo_ in order to talk to the docker daemon. If you wish to have it on, please use the experimental 
 ```SudoMechanism``` to setup how to do this. More description can be found in the _Talking to Docker Daemon_ chapter.
 If you wish to turn off _sudo_ to communicate with the docker daemon, you can follow a docker tutorial at 
 https://docs.docker.com/install/linux/docker-ce/ubuntu/ and do the last step of adding your user to docker group._
+
+**Note:** If you're using Podman, it typically doesn't require sudo since it's designed to run rootless by default.
 
 The fluent _API_ builds up one or more services. Each service may be composite or singular. Therefore it is possible
 to e.g. fire up several _docker-compose_ based services and manage each of them as a single service or dig in and use
@@ -675,9 +703,11 @@ The above snippet fires up the wordpress docker compose project and checks the _
 (in this case "https://wordpress.org/"). If not it returns _500_ and the ```WaitForHttp``` function will wait 500 milliseconds before invoking again. This works for any custom
 lambda as well, just use ```WaitFor``` instead. Thus it is possible to e.g. query a database before continuing inside the using scope.
 
-## Talking to Docker Daemon
+## Talking to Container Engine Daemon
 For Linux and Mac users there are several options how to authenticate towards the socket. _FluentDocker_ supports no _sudo_, _sudo_ without any password (user added as NOPASSWD in /etc/sudoer), or
-_sudo_ with password. The default is that FluentDocker expects to be able to talk without any _sudo_. The options ar global but can be changed in runtime.
+_sudo_ with password. The default is that FluentDocker expects to be able to talk without any _sudo_. The options are global but can be changed in runtime.
+
+**Note:** If you're using Podman, it typically doesn't require sudo since it's designed to run rootless by default. Docker may require sudo depending on your system configuration.
 
 ```cs
      SudoMechanism.None.SetSudo(); // This is the default


### PR DESCRIPTION
This pull request introduces comprehensive support for selecting and working with different container engines (Docker and Podman) throughout the FluentDocker library. It adds the ability to specify a preferred engine, improves binary resolution, and ensures that commands and error handling are aware of the active engine. The changes also enhance compatibility with Podman and unify Compose handling.

Container engine selection and resolution:

* Added a new `SetContainerEngine` extension method and related properties to `CommandExtensions`, allowing users to specify and query the preferred and active container engine (`Docker`, `Podman`, or `Auto`). All binary resolution and command execution now respect this setting. [[1]](diffhunk://#diff-e4d23c3a2cad262bad46708d21509a128d89ffbdc00e1ff5ddb7efc22cc3c3eaL83-R137) [[2]](diffhunk://#diff-e4d23c3a2cad262bad46708d21509a128d89ffbdc00e1ff5ddb7efc22cc3c3eaR21-R23) [[3]](diffhunk://#diff-e4d23c3a2cad262bad46708d21509a128d89ffbdc00e1ff5ddb7efc22cc3c3eaL73-R74)
* Updated `DockerBinariesResolver` to support engine preference, resolve both Docker and Podman binaries, and expose which engine is actually being used. The resolver now logs and throws errors specific to the missing engine. [[1]](diffhunk://#diff-37cfbd43855342c093ad5ee01d4a2a04b28bcca02a04e4165d40fbeecef83e6cL13-R84) [[2]](diffhunk://#diff-37cfbd43855342c093ad5ee01d4a2a04b28bcca02a04e4165d40fbeecef83e6cR97-R106) [[3]](diffhunk://#diff-37cfbd43855342c093ad5ee01d4a2a04b28bcca02a04e4165d40fbeecef83e6cL88-R136) [[4]](diffhunk://#diff-37cfbd43855342c093ad5ee01d4a2a04b28bcca02a04e4165d40fbeecef83e6cR167-R169) [[5]](diffhunk://#diff-37cfbd43855342c093ad5ee01d4a2a04b28bcca02a04e4165d40fbeecef83e6cR182-R220)

Command and Compose handling improvements:

* Normalized command names so that Podman and Docker commands are interchangeable where possible, and unified Compose V1 and V2 handling for both engines. Compose detection and reporting now includes both V1 and V2, and output is more descriptive. [[1]](diffhunk://#diff-e4d23c3a2cad262bad46708d21509a128d89ffbdc00e1ff5ddb7efc22cc3c3eaL117-R190) [[2]](diffhunk://#diff-e4d23c3a2cad262bad46708d21509a128d89ffbdc00e1ff5ddb7efc22cc3c3eaL147-R228)
* Updated Compose V2 detection logic to work for both Docker and Podman, and improved error logging for missing binaries.

Podman-specific handling and error messages:

* Modified engine-switching commands (`Switch`, `LinuxDaemon`, `WindowsDaemon` in `Info.cs`) to return appropriate responses or errors when Podman is selected, since Podman does not support Docker Desktop-specific features.
* Improved error messages and logging throughout to clearly indicate which engine is missing or unsupported in various scenarios. [[1]](diffhunk://#diff-37cfbd43855342c093ad5ee01d4a2a04b28bcca02a04e4165d40fbeecef83e6cL13-R84) [[2]](diffhunk://#diff-4d8623d0ce8a96d9c28c2ad49857e58c6920fac369d66eb825637144dc6d119bL43-R101)

These changes make the library more flexible and robust when working with different container environments, especially in mixed or Podman-only setups.