### PR TITLE
Address remaining v2-era community PRs: Podman parsing + UTF-8 CLI streams

### DIFF
--- a/FluentDocker.Tests/CoreTests/Driver/DockerApi/DockerApiContainerDriverPodmanCompatTests.cs
+++ b/FluentDocker.Tests/CoreTests/Driver/DockerApi/DockerApiContainerDriverPodmanCompatTests.cs
@@ -1,0 +1,134 @@
+using System.Threading.Tasks;
+using FluentDocker.Drivers;
+using FluentDocker.Drivers.Docker.Api.Components;
+using FluentDocker.Model.Containers;
+using FluentDocker.Model.Drivers;
+using Xunit;
+
+namespace FluentDocker.Tests.CoreTests.Driver.DockerApi
+{
+  // Inspection-parsing tolerance for podman-api-compat responses: Entrypoint
+  // and Cmd may arrive as a single string, and Health.Status may be an empty
+  // string instead of an omitted field. See community PR #303 (Rory Reid).
+  [Trait("Category", "Unit")]
+  public class DockerApiContainerDriverPodmanCompatTests
+  {
+    private static DriverContext Ctx => new("docker-api-test");
+
+    private static (DockerApiContainerDriver driver, MockDockerApiConnection mock) CreateDriver()
+    {
+      var mock = new MockDockerApiConnection();
+      var driver = new DockerApiContainerDriver(mock);
+      driver.Initialize(new DriverContext("docker-api-test"));
+      return (driver, mock);
+    }
+
+    [Fact]
+    public async Task InspectAsync_EntrypointAsArray_ParsesAsArray()
+    {
+      const string json = @"{""Id"":""x"",""Config"":{""Entrypoint"":[""docker-entrypoint.sh""]}}";
+      var (driver, mock) = CreateDriver();
+      mock.SetupGet("/json", 200, json);
+
+      var result = await driver.InspectAsync(Ctx, "x", cancellationToken: TestContext.Current.CancellationToken);
+
+      Assert.True(result.Success);
+      Assert.Equal(new[] { "docker-entrypoint.sh" }, result.Data.Config.EntryPoint);
+    }
+
+    [Fact]
+    public async Task InspectAsync_EntrypointAsSingleString_ParsesAsSingleElementArray()
+    {
+      // Podman sometimes emits Entrypoint as a bare string instead of an array.
+      const string json = @"{""Id"":""x"",""Config"":{""Entrypoint"":""docker-entrypoint.sh""}}";
+      var (driver, mock) = CreateDriver();
+      mock.SetupGet("/json", 200, json);
+
+      var result = await driver.InspectAsync(Ctx, "x", cancellationToken: TestContext.Current.CancellationToken);
+
+      Assert.True(result.Success);
+      Assert.Equal(new[] { "docker-entrypoint.sh" }, result.Data.Config.EntryPoint);
+    }
+
+    [Fact]
+    public async Task InspectAsync_CmdAsSingleString_ParsesAsSingleElementArray()
+    {
+      const string json = @"{""Id"":""x"",""Config"":{""Cmd"":""postgres""}}";
+      var (driver, mock) = CreateDriver();
+      mock.SetupGet("/json", 200, json);
+
+      var result = await driver.InspectAsync(Ctx, "x", cancellationToken: TestContext.Current.CancellationToken);
+
+      Assert.True(result.Success);
+      Assert.Equal(new[] { "postgres" }, result.Data.Config.Cmd);
+    }
+
+    [Fact]
+    public async Task InspectAsync_HealthBlockHealthyStatus_ParsesToHealthy()
+    {
+      const string json = @"{""Id"":""x"",""State"":{""Status"":""running"","
+          + @"""Health"":{""Status"":""healthy"",""FailingStreak"":0,""Log"":[]}}}";
+      var (driver, mock) = CreateDriver();
+      mock.SetupGet("/json", 200, json);
+
+      var result = await driver.InspectAsync(Ctx, "x", cancellationToken: TestContext.Current.CancellationToken);
+
+      Assert.True(result.Success);
+      Assert.NotNull(result.Data.State.Health);
+      Assert.Equal(HealthState.Healthy, result.Data.State.Health.Status);
+      Assert.Equal(0, result.Data.State.Health.FailingStreak);
+    }
+
+    [Fact]
+    public async Task InspectAsync_HealthBlockEmptyStatus_ParsesToUnknown()
+    {
+      // Podman emits Health.Status as an empty string in some states (e.g. "created").
+      const string json = @"{""Id"":""x"",""State"":{""Status"":""created"","
+          + @"""Health"":{""Status"":"""",""FailingStreak"":0,""Log"":null}}}";
+      var (driver, mock) = CreateDriver();
+      mock.SetupGet("/json", 200, json);
+
+      var result = await driver.InspectAsync(Ctx, "x", cancellationToken: TestContext.Current.CancellationToken);
+
+      Assert.True(result.Success);
+      Assert.NotNull(result.Data.State.Health);
+      Assert.Equal(HealthState.Unknown, result.Data.State.Health.Status);
+    }
+
+    [Fact]
+    public async Task InspectAsync_HealthBlockMissing_LeavesHealthNull()
+    {
+      const string json = @"{""Id"":""x"",""State"":{""Status"":""running""}}";
+      var (driver, mock) = CreateDriver();
+      mock.SetupGet("/json", 200, json);
+
+      var result = await driver.InspectAsync(Ctx, "x", cancellationToken: TestContext.Current.CancellationToken);
+
+      Assert.True(result.Success);
+      Assert.Null(result.Data.State.Health);
+    }
+
+    [Fact]
+    public async Task InspectAsync_HealthBlockWithLog_ParsesLogEntries()
+    {
+      const string json = @"{""Id"":""x"",""State"":{""Status"":""running"","
+          + @"""Health"":{""Status"":""unhealthy"",""FailingStreak"":3,"
+          + @"""Log"":[{""Start"":""2026-05-11T10:00:00Z"",""End"":""2026-05-11T10:00:01Z"","
+          + @"""ExitCode"":1,""Output"":""boom""}]}}}";
+      var (driver, mock) = CreateDriver();
+      mock.SetupGet("/json", 200, json);
+
+      var result = await driver.InspectAsync(Ctx, "x", cancellationToken: TestContext.Current.CancellationToken);
+
+      Assert.True(result.Success);
+      var health = result.Data.State.Health;
+      Assert.NotNull(health);
+      Assert.Equal(HealthState.Unhealthy, health.Status);
+      Assert.Equal(3, health.FailingStreak);
+      Assert.NotNull(health.Log);
+      Assert.Single(health.Log);
+      Assert.Equal(1, health.Log[0].ExitCode);
+      Assert.Equal("boom", health.Log[0].Output);
+    }
+  }
+}

--- a/FluentDocker.Tests/CoreTests/Model/ProcessRowTests.cs
+++ b/FluentDocker.Tests/CoreTests/Model/ProcessRowTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using FluentDocker.Model.Containers;
+using Xunit;
+
+namespace FluentDocker.Tests.CoreTests.Model
+{
+  [Trait("Category", "Unit")]
+  public class ProcessRowTests
+  {
+    // ProcessRow.ToRow is internal. Invoke via reflection.
+    private static ProcessRow ToRow(IList<string> columns, IList<string> values)
+    {
+      var method = typeof(ProcessRow).GetMethod(
+          "ToRow",
+          BindingFlags.NonPublic | BindingFlags.Static);
+      return (ProcessRow)method.Invoke(null, [columns, values]);
+    }
+
+    [Fact]
+    public void ToRow_StandardHmsForm_ParsesStartedAndTime()
+    {
+      var row = ToRow(["START", "TIME"], ["00:00:12", "00:01:30"]);
+
+      Assert.Equal(TimeSpan.FromSeconds(12), row.Started);
+      Assert.Equal(TimeSpan.FromSeconds(90), row.Time);
+    }
+
+    [Theory]
+    [InlineData("0s", 0)]
+    [InlineData("12s", 12)]
+    [InlineData("59s", 59)]
+    public void ToRow_PodmanSecondsForm_ParsesStarted(string value, int expectedSeconds)
+    {
+      var row = ToRow(["START"], [value]);
+
+      Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), row.Started);
+    }
+
+    [Theory]
+    [InlineData("0m0s", 0, 0)]
+    [InlineData("12m34s", 12, 34)]
+    [InlineData("5m9s", 5, 9)]
+    public void ToRow_PodmanMinutesSecondsForm_ParsesTime(string value, int minutes, int seconds)
+    {
+      var row = ToRow(["TIME"], [value]);
+
+      Assert.Equal(new TimeSpan(0, minutes, seconds), row.Time);
+    }
+
+    [Theory]
+    [InlineData("0h0m0s", 0, 0, 0)]
+    [InlineData("1h2m3s", 1, 2, 3)]
+    [InlineData("12h34m56s", 12, 34, 56)]
+    public void ToRow_PodmanHoursMinutesSecondsForm_ParsesStarted(string value, int hours, int minutes, int seconds)
+    {
+      var row = ToRow(["START"], [value]);
+
+      Assert.Equal(new TimeSpan(hours, minutes, seconds), row.Started);
+    }
+
+    [Fact]
+    public void ToRow_PodmanCpuColumnAcceptsSecondsForm()
+    {
+      var row = ToRow(["CPU"], ["7s"]);
+
+      Assert.Equal(TimeSpan.FromSeconds(7), row.Cpu);
+    }
+
+    [Fact]
+    public void ToRow_CpuColumnGarbageInput_LeavesCpuAtDefault()
+    {
+      var row = ToRow(["CPU"], ["not-a-duration"]);
+
+      Assert.Equal(TimeSpan.Zero, row.Cpu);
+    }
+
+    [Fact]
+    public void ToRow_StartedColumnGarbage_Throws()
+    {
+      // Started uses the throwing form (Parse). A genuinely malformed value
+      // should still surface as an exception — we don't want to silently
+      // mask future container-engine quirks by widening the contract.
+      var ex = Assert.Throws<TargetInvocationException>(() => ToRow(["START"], ["totally-garbage"]));
+      Assert.IsType<FormatException>(ex.InnerException);
+    }
+  }
+}

--- a/FluentDocker/Drivers/Docker/Api/Components/DockerApiContainerDriver.Parsing.cs
+++ b/FluentDocker/Drivers/Docker/Api/Components/DockerApiContainerDriver.Parsing.cs
@@ -279,8 +279,50 @@ namespace FluentDocker.Drivers.Docker.Api.Components
         ExitCode = el.GetInt64OrDefault("ExitCode"),
         Error = el.GetStringOrDefault("Error"),
         StartedAt = el.GetDateTimeOrDefault("StartedAt"),
-        FinishedAt = el.GetDateTimeOrDefault("FinishedAt")
+        FinishedAt = el.GetDateTimeOrDefault("FinishedAt"),
+        Health = ParseHealth(el.Prop("Health") ?? el.Prop("Healthcheck"))
       };
+    }
+
+    // Podman-compat (and some Docker versions) emit Health.Status as an empty
+    // string instead of omitting the field. Default to HealthState.Unknown so
+    // enum parsing doesn't throw.
+    private static Health ParseHealth(JsonElement? healthToken)
+    {
+      if (healthToken == null || healthToken.Value.IsNullOrUndefined())
+        return null;
+
+      var el = healthToken.Value;
+      var statusStr = el.GetStringOrDefault("Status");
+      HealthState status;
+      if (string.IsNullOrEmpty(statusStr))
+        status = HealthState.Unknown;
+      else if (!Enum.TryParse(statusStr, ignoreCase: true, out status))
+        status = HealthState.Unknown;
+
+      var health = new Health
+      {
+        Status = status,
+        FailingStreak = el.GetInt32OrDefault("FailingStreak")
+      };
+
+      var logProp = el.Prop("Log");
+      if (logProp.HasValue && logProp.Value.ValueKind == JsonValueKind.Array)
+      {
+        health.Log = [];
+        foreach (var entry in logProp.Value.EnumerateArray())
+        {
+          health.Log.Add(new HealthLog
+          {
+            Start = entry.GetStringOrDefault("Start"),
+            End = entry.GetStringOrDefault("End"),
+            ExitCode = entry.GetInt32OrDefault("ExitCode"),
+            Output = entry.GetStringOrDefault("Output")
+          });
+        }
+      }
+
+      return health;
     }
 
     private static ContainerConfig ParseContainerConfig(JsonElement? element)
@@ -296,8 +338,8 @@ namespace FluentDocker.Drivers.Docker.Api.Components
         OpenStdin = el.GetBoolOrDefault("OpenStdin"),
         Image = el.GetStringOrDefault("Image"),
         WorkingDir = el.GetStringOrDefault("WorkingDir"),
-        Cmd = el.GetStringArray("Cmd"),
-        EntryPoint = el.GetStringArray("Entrypoint"),
+        Cmd = el.GetStringOrArray("Cmd"),
+        EntryPoint = el.GetStringOrArray("Entrypoint"),
         Env = el.GetStringArray("Env"),
         Labels = el.GetStringDictionary("Labels"),
         StopSignal = el.GetStringOrDefault("StopSignal")

--- a/FluentDocker/Drivers/Docker/Cli/DockerCliDriverBase.cs
+++ b/FluentDocker/Drivers/Docker/Cli/DockerCliDriverBase.cs
@@ -203,7 +203,9 @@ namespace FluentDocker.Drivers.Docker.Cli
             RedirectStandardError = true,
             RedirectStandardInput = needsStdin,
             UseShellExecute = false,
-            CreateNoWindow = true
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8
           }
         };
 
@@ -292,7 +294,9 @@ namespace FluentDocker.Drivers.Docker.Cli
           RedirectStandardError = true,
           RedirectStandardInput = passwordForStdin != null,
           UseShellExecute = false,
-          CreateNoWindow = true
+          CreateNoWindow = true,
+          StandardOutputEncoding = Encoding.UTF8,
+          StandardErrorEncoding = Encoding.UTF8
         }
       };
 
@@ -346,7 +350,9 @@ namespace FluentDocker.Drivers.Docker.Cli
           RedirectStandardOutput = true,
           RedirectStandardError = true,
           UseShellExecute = false,
-          CreateNoWindow = true
+          CreateNoWindow = true,
+          StandardOutputEncoding = Encoding.UTF8,
+          StandardErrorEncoding = Encoding.UTF8
         }
       };
 

--- a/FluentDocker/Drivers/Podman/Cli/PodmanCliDriverBase.cs
+++ b/FluentDocker/Drivers/Podman/Cli/PodmanCliDriverBase.cs
@@ -164,7 +164,9 @@ namespace FluentDocker.Drivers.Podman.Cli
             RedirectStandardError = true,
             RedirectStandardInput = needsStdin,
             UseShellExecute = false,
-            CreateNoWindow = true
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8
           }
         };
 
@@ -244,7 +246,9 @@ namespace FluentDocker.Drivers.Podman.Cli
           RedirectStandardError = true,
           RedirectStandardInput = passwordForStdin != null,
           UseShellExecute = false,
-          CreateNoWindow = true
+          CreateNoWindow = true,
+          StandardOutputEncoding = Encoding.UTF8,
+          StandardErrorEncoding = Encoding.UTF8
         }
       };
 
@@ -297,7 +301,9 @@ namespace FluentDocker.Drivers.Podman.Cli
           RedirectStandardOutput = true,
           RedirectStandardError = true,
           UseShellExecute = false,
-          CreateNoWindow = true
+          CreateNoWindow = true,
+          StandardOutputEncoding = Encoding.UTF8,
+          StandardErrorEncoding = Encoding.UTF8
         }
       };
 

--- a/FluentDocker/Model/Containers/ProcessRow.cs
+++ b/FluentDocker/Model/Containers/ProcessRow.cs
@@ -65,10 +65,10 @@ namespace FluentDocker.Model.Containers
             break;
           case StartConst:
           case StartTimeConst:
-            row.Started = TimeSpan.Parse(fullRow[i]);
+            row.Started = ParseDuration(fullRow[i]);
             break;
           case TimeConst:
-            row.Time = TimeSpan.Parse(fullRow[i]);
+            row.Time = ParseDuration(fullRow[i]);
             break;
           case TerminalConst:
             row.Tty = fullRow[i];
@@ -77,7 +77,7 @@ namespace FluentDocker.Model.Containers
             row.Status = fullRow[i];
             break;
           case CpuTime:
-            if (TimeSpan.TryParse(fullRow[i], out var cpuTime))
+            if (TryParseDuration(fullRow[i], out var cpuTime))
               row.Cpu = cpuTime;
             break;
           case PercentCpuConst:
@@ -90,6 +90,30 @@ namespace FluentDocker.Model.Containers
       }
 
       return row;
+    }
+
+    // Podman top emits durations like "0s", "12m34s", "1h2m3s" rather than the
+    // hh:mm:ss form that TimeSpan.Parse accepts. Fall back through the podman
+    // shapes so cross-engine consumers don't get FormatException.
+    private static TimeSpan ParseDuration(string value)
+    {
+      if (TryParseDuration(value, out var result))
+        return result;
+
+      return TimeSpan.Parse(value, CultureInfo.InvariantCulture);
+    }
+
+    private static bool TryParseDuration(string value, out TimeSpan result)
+    {
+      if (TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out result))
+        return true;
+      if (TimeSpan.TryParseExact(value, @"%s\s", CultureInfo.InvariantCulture, out result))
+        return true;
+      if (TimeSpan.TryParseExact(value, @"%m\m%s\s", CultureInfo.InvariantCulture, out result))
+        return true;
+      if (TimeSpan.TryParseExact(value, @"%h\h%m\m%s\s", CultureInfo.InvariantCulture, out result))
+        return true;
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Credits

This PR completes the v3 absorption of three open community PRs targeted at the old v2 namespace. Thanks to:

- **@Rory-Reid** ([#303](https://github.com/mariotoffia/FluentDocker/pull/303)) — Podman parsing tolerance. The `ProcessRow` duration helpers and the Docker API driver hardening for `Entrypoint`/`Health.Status` are grounded in this PR's diff and JSON fixtures.
- **@jellever** ([#331](https://github.com/mariotoffia/FluentDocker/pull/331)) — UTF-8 process I/O on the CLI driver `ProcessStartInfo` paths is taken directly from this PR.
- **@donal-lgc** ([#319](https://github.com/mariotoffia/FluentDocker/pull/319)) — `:bulb` README typo report; the offending paragraph was rewritten in v3 so no code change is needed.

## What this fixes

| Fix | Commit | Notes |
|---|---|---|
| `ProcessRow.ToRow` throws on Podman `top` duration formats (`0s`, `12m34s`, `1h2m3s`) | 003d040 | Real bug — any consumer of `top` against Podman saw `FormatException`. |
| CLI driver stdout/stderr use system code page, mangling non-ASCII | faa438a | Real bug — six identical `Encoding.UTF8` additions across Docker and Podman CLI drivers. Most plausible suspect behind community report #329. |
| Docker API driver's `Config.Entrypoint` / `Config.Cmd` assume array | 377fa1d | Defensive — swap to existing `GetStringOrArray` extension. Required if pointed at podman-api-compat. |
| Docker API driver was silently dropping `State.Health` entirely | 377fa1d | Feature gap — adds `ParseHealth` mirroring `PodmanContainerParser`, with empty-`Status` → `HealthState.Unknown` defensive handling. |

## Already absorbed by the v3 refactor (so not in this PR)

PR #331's compose `--project-directory` / `-p` quoting, sudo executor unification, and `showTimeStamps` parameter are all handled by the v3 redesign (`DockerCliComposeDriver.BuildComposeArgs`, `BuildSudoCommand`, `StreamLogsConfig.Timestamps`). PR #303's `Health.Status` empty-string and `Entrypoint` string-or-array handling are handled in the Podman CLI parser (`PodmanContainerParser`).

## Test plan

- [x] `make build` — 0 errors, 216 pre-existing warnings (no new warnings)
- [x] `make test` — 3,135 / 3,138 pass (3 pre-existing skipped, 0 failures)
- [x] 20 new unit tests:
  - 13 in `ProcessRowTests` covering all three Podman duration shapes plus standard `hh:mm:ss` and a garbage-input regression
  - 7 in `DockerApiContainerDriverPodmanCompatTests` covering Entrypoint-as-string, Cmd-as-string, Health healthy/unhealthy/empty/missing, and `Log` entry parsing

## After merge

Close #303, #319, #331 with thanks and a pointer to this PR (and to the v3 commits where the rest was absorbed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)