### PR TITLE
fix(#335): tolerate numeric JSON in string inspect fields

### DIFF
--- a/FluentDocker.Tests/CoreTests/Common/TolerantStringConverterTests.cs
+++ b/FluentDocker.Tests/CoreTests/Common/TolerantStringConverterTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentDocker.Common;
+using Xunit;
+
+namespace FluentDocker.Tests.CoreTests.Common
+{
+  /// <summary>
+  /// Unit tests for <see cref="TolerantStringConverter"/> (issue #335): JSON numbers
+  /// and booleans landing in <see cref="string"/> properties must be read leniently
+  /// instead of throwing, while genuine strings and nulls pass through unchanged.
+  /// </summary>
+  [Trait("Category", "Unit")]
+  public class TolerantStringConverterTests
+  {
+    private static readonly JsonSerializerOptions Options = CreateOptions();
+
+    private static JsonSerializerOptions CreateOptions()
+    {
+      var o = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+      o.Converters.Add(new TolerantStringConverter());
+      return o;
+    }
+
+    private sealed class Holder
+    {
+      public string Value { get; set; }
+    }
+
+    [Theory]
+    [InlineData("0", "0")]
+    [InlineData("16", "16")]
+    [InlineData("-1", "-1")]
+    [InlineData("1500000000", "1500000000")]
+    [InlineData("3.14", "3.14")]
+    public void Read_JsonNumber_PreservesLiteralText(string jsonNumber, string expected)
+    {
+      var holder = JsonSerializer.Deserialize<Holder>($$"""{"Value": {{jsonNumber}} }""", Options);
+      Assert.Equal(expected, holder.Value);
+    }
+
+    [Theory]
+    [InlineData("true", "true")]
+    [InlineData("false", "false")]
+    public void Read_JsonBoolean_BecomesLiteralText(string jsonBool, string expected)
+    {
+      var holder = JsonSerializer.Deserialize<Holder>($$"""{"Value": {{jsonBool}} }""", Options);
+      Assert.Equal(expected, holder.Value);
+    }
+
+    [Fact]
+    public void Read_JsonString_PassesThrough()
+    {
+      var holder = JsonSerializer.Deserialize<Holder>("""{"Value":"hello"}""", Options);
+      Assert.Equal("hello", holder.Value);
+    }
+
+    [Fact]
+    public void Read_JsonNull_BecomesNull()
+    {
+      var holder = JsonSerializer.Deserialize<Holder>("""{"Value":null}""", Options);
+      Assert.Null(holder.Value);
+    }
+
+    [Fact]
+    public void Write_String_RoundTrips()
+    {
+      var json = JsonSerializer.Serialize(new Holder { Value = "abc" }, Options);
+      Assert.Contains("\"abc\"", json);
+    }
+
+    [Fact]
+    public void Write_Null_WritesJsonNull()
+    {
+      var json = JsonSerializer.Serialize(new Holder { Value = null }, Options);
+      Assert.Contains("null", json);
+    }
+  }
+}

--- a/FluentDocker.Tests/CoreTests/Driver/Docker/DockerCliContainerDriverTests.NetworkParsing.cs
+++ b/FluentDocker.Tests/CoreTests/Driver/Docker/DockerCliContainerDriverTests.NetworkParsing.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using FluentDocker.Common;
+using Xunit;
+using Container = FluentDocker.Model.Containers.Container;
+
+namespace FluentDocker.Tests.CoreTests.Driver.Docker
+{
+  /// <summary>
+  /// Regression tests for issue #335: <c>docker inspect</c> emits
+  /// <c>NetworkSettings.LinkLocalIPv6PrefixLen</c>, <c>GlobalIPv6PrefixLen</c> and
+  /// <c>IPPrefixLen</c> as JSON <em>numbers</em>, but the model types them as
+  /// <see cref="string"/>. System.Text.Json threw on the number-into-string mismatch,
+  /// which surfaced as a <c>DriverException: Failed to inspect container</c>. The
+  /// <see cref="TolerantStringConverter"/> restores lenient parsing.
+  /// </summary>
+  public partial class DockerCliContainerDriverTests
+  {
+    #region Network Settings Numeric Prefix Length Parsing (issue #335)
+
+    [Fact]
+    public void InspectParsing_NumericNetworkPrefixLengths_DoesNotThrow()
+    {
+      // Mirrors the exact shape `docker inspect` returns: prefix-len fields are numbers.
+      var json = @"[{
+        ""Id"": ""abc123"",
+        ""Name"": ""/ipv6-container"",
+        ""NetworkSettings"": {
+          ""IPAddress"": ""172.17.0.2"",
+          ""IPPrefixLen"": 16,
+          ""GlobalIPv6Address"": ""2001:db8::2"",
+          ""GlobalIPv6PrefixLen"": 64,
+          ""LinkLocalIPv6Address"": ""fe80::42:acff:fe11:2"",
+          ""LinkLocalIPv6PrefixLen"": 0
+        }
+      }]";
+
+      var ex = Record.Exception(() => JsonSerializer.Deserialize<List<Container>>(
+          json, JsonHelper.CaseInsensitiveOptions));
+
+      Assert.Null(ex);
+    }
+
+    [Fact]
+    public void InspectParsing_NumericNetworkPrefixLengths_PreservesValuesAsStrings()
+    {
+      var json = @"[{
+        ""Id"": ""abc123"",
+        ""Name"": ""/ipv6-container"",
+        ""NetworkSettings"": {
+          ""IPPrefixLen"": 16,
+          ""GlobalIPv6PrefixLen"": 64,
+          ""LinkLocalIPv6PrefixLen"": 0
+        }
+      }]";
+
+      var ns = JsonSerializer.Deserialize<List<Container>>(
+          json, JsonHelper.CaseInsensitiveOptions)?.FirstOrDefault()?.NetworkSettings;
+
+      Assert.NotNull(ns);
+      Assert.Equal("16", ns.IPPrefixLen);
+      Assert.Equal("64", ns.GlobalIPv6PrefixLen);
+      Assert.Equal("0", ns.LinkLocalIPv6PrefixLen);
+    }
+
+    [Fact]
+    public void InspectParsing_StringNetworkPrefixLengths_StillParse()
+    {
+      // Some engines (and Podman) emit these as strings; that must keep working.
+      var json = @"[{
+        ""Id"": ""abc123"",
+        ""NetworkSettings"": { ""IPPrefixLen"": ""24"" }
+      }]";
+
+      var ns = JsonSerializer.Deserialize<List<Container>>(
+          json, JsonHelper.CaseInsensitiveOptions)?.FirstOrDefault()?.NetworkSettings;
+
+      Assert.NotNull(ns);
+      Assert.Equal("24", ns.IPPrefixLen);
+    }
+
+    #endregion
+  }
+}

--- a/FluentDocker/Common/JsonHelper.cs
+++ b/FluentDocker/Common/JsonHelper.cs
@@ -169,6 +169,7 @@ namespace FluentDocker.Common
         PropertyNameCaseInsensitive = false
       };
       options.Converters.Add(new JsonStringEnumConverter());
+      options.Converters.Add(new TolerantStringConverter());
       return options;
     }
 
@@ -183,6 +184,7 @@ namespace FluentDocker.Common
         PropertyNameCaseInsensitive = true
       };
       options.Converters.Add(new JsonStringEnumConverter());
+      options.Converters.Add(new TolerantStringConverter());
       return options;
     }
 
@@ -197,6 +199,7 @@ namespace FluentDocker.Common
         PropertyNameCaseInsensitive = true
       };
       options.Converters.Add(new JsonStringEnumConverter());
+      options.Converters.Add(new TolerantStringConverter());
       return options;
     }
   }

--- a/FluentDocker/Common/TolerantStringConverter.cs
+++ b/FluentDocker/Common/TolerantStringConverter.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FluentDocker.Common
+{
+  /// <summary>
+  /// A <see cref="JsonConverter{T}"/> for <see cref="string"/> that tolerates JSON
+  /// values which are not string tokens. Docker and Podman <c>inspect</c> output is
+  /// inconsistent: several fields that FluentDocker models as <see cref="string"/>
+  /// (for example <c>NetworkSettings.LinkLocalIPv6PrefixLen</c>, <c>GlobalIPv6PrefixLen</c>
+  /// and <c>IPPrefixLen</c>) are emitted by the Docker engine as JSON <em>numbers</em>.
+  /// </summary>
+  /// <remarks>
+  /// System.Text.Json throws when a JSON number (or boolean) is deserialized into a
+  /// <see cref="string"/> property. Newtonsoft.Json (used in FluentDocker v2) silently
+  /// coerced these, so the v3 switch to System.Text.Json regressed inspect parsing for
+  /// those containers. This converter restores the lenient behavior by reading the raw
+  /// literal text of <c>Number</c>, <c>True</c> and <c>False</c> tokens into the string,
+  /// preserving the exact representation (e.g. <c>0</c> stays <c>"0"</c>). Genuine string
+  /// and null tokens are passed through unchanged.
+  /// </remarks>
+  public sealed class TolerantStringConverter : JsonConverter<string>
+  {
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+      switch (reader.TokenType)
+      {
+        case JsonTokenType.String:
+          return reader.GetString();
+        case JsonTokenType.Null:
+          return null;
+        case JsonTokenType.Number:
+        case JsonTokenType.True:
+        case JsonTokenType.False:
+          // Read the raw literal bytes of the token and decode as UTF-8 so the
+          // exact representation is preserved (e.g. "0", "16", "true").
+          var bytes = reader.HasValueSequence
+              ? reader.ValueSequence.ToArray()
+              : reader.ValueSpan.ToArray();
+          return Encoding.UTF8.GetString(bytes);
+        default:
+          throw new JsonException(
+              $"Cannot convert JSON token '{reader.TokenType}' to System.String.");
+      }
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+      if (value is null)
+        writer.WriteNullValue();
+      else
+        writer.WriteStringValue(value);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #335

## Problem
`docker inspect` emits `NetworkSettings.LinkLocalIPv6PrefixLen`, `GlobalIPv6PrefixLen` and `IPPrefixLen` as JSON **numbers**, but the `ContainerNetworkSettings` model types them as `string`. FluentDocker v2 used Newtonsoft.Json, which silently coerced number→string. The v3 switch to System.Text.Json regressed this path: STJ throws `The JSON value could not be converted to System.String`, which `DockerCliContainerDriver.InspectAsync` surfaces as `DriverException: Failed to inspect container '...'` — exactly the report in #335.

## Fix
A `TolerantStringConverter : JsonConverter<string>` that reads `Number`/`True`/`False` tokens as their **literal text** (lossless — `0` → `"0"`, `16` → `"16"`), while genuine `String` and `Null` tokens pass through unchanged. Registered on all `JsonHelper` option sets so it covers any number-in-a-string field across Docker/Podman inspect output.

**Non-breaking:** the public model fields stay `string` (no API change). Considered changing the three fields to `int` for consistency with `BridgeNetwork`, but that breaks consumers reading them as text in an already-released v3, so the converter is preferred.

## Tests
- `TolerantStringConverterTests` — number/boolean/string/null reads + write round-trip.
- `DockerCliContainerDriverTests.NetworkParsing` — deserializes an `inspect` array with numeric prefix-len fields, asserts no throw and that values are preserved as strings; also confirms string-form values still parse (Podman compatibility).

Full unit suite: **3149 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)