### PR TITLE
feat(#267): expose container Kill at the service level

### DIFF
--- a/FluentDocker.Tests/CoreTests/Service/ContainerServiceTests.Operations.cs
+++ b/FluentDocker.Tests/CoreTests/Service/ContainerServiceTests.Operations.cs
@@ -179,6 +179,90 @@ namespace FluentDocker.Tests.CoreTests.Service
 
     [Fact]
     [Trait("Category", "Unit")]
+    public async Task KillAsync_CallsDriverWithSignalAndUpdatesState()
+    {
+      // Arrange
+      var mockPack = new MockDriverPack();
+      mockPack.SetupContainerKill();
+
+      var kernel = await MockKernelBuilderExtensions.CreateWithMockDriverAsync("docker", mockPack);
+
+      var service = new ContainerService(kernel, "docker", "test-container-123", "nginx:latest", "test-container");
+
+      try
+      {
+        // Act
+        await service.KillAsync("SIGTERM", cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(ServiceRunningState.Stopped, service.State);
+        mockPack.ContainerDriver.Verify(d => d.KillAsync(
+            It.IsAny<FluentDocker.Model.Drivers.DriverContext>(),
+            It.Is<string>(s => s == "test-container-123"),
+            It.Is<string>(sig => sig == "SIGTERM"),
+            It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+      }
+      finally
+      {
+        kernel.Dispose();
+      }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task KillAsync_DefaultsToSigkill()
+    {
+      var mockPack = new MockDriverPack();
+      mockPack.SetupContainerKill();
+      var kernel = await MockKernelBuilderExtensions.CreateWithMockDriverAsync("docker", mockPack);
+      var service = new ContainerService(kernel, "docker", "test-container-123", "nginx:latest", "test-container");
+
+      try
+      {
+        await service.KillAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        mockPack.ContainerDriver.Verify(d => d.KillAsync(
+            It.IsAny<FluentDocker.Model.Drivers.DriverContext>(),
+            It.IsAny<string>(),
+            It.Is<string>(sig => sig == "SIGKILL"),
+            It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+      }
+      finally
+      {
+        kernel.Dispose();
+      }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task KillAsync_DriverFailure_ThrowsDriverException()
+    {
+      var mockPack = new MockDriverPack();
+      mockPack.ContainerDriver
+          .Setup(d => d.KillAsync(
+              It.IsAny<FluentDocker.Model.Drivers.DriverContext>(),
+              It.IsAny<string>(),
+              It.IsAny<string>(),
+              It.IsAny<System.Threading.CancellationToken>()))
+          .ReturnsAsync(FluentDocker.Model.Drivers.CommandResponse<FluentDocker.Model.Drivers.Unit>.Fail(
+              "no such container", "CONTAINER_KILL_FAILED"));
+
+      var kernel = await MockKernelBuilderExtensions.CreateWithMockDriverAsync("docker", mockPack);
+      var service = new ContainerService(kernel, "docker", "test-container-123", "nginx:latest", "test-container");
+
+      try
+      {
+        await Assert.ThrowsAsync<FluentDocker.Common.DriverException>(
+            () => service.KillAsync(cancellationToken: TestContext.Current.CancellationToken));
+      }
+      finally
+      {
+        kernel.Dispose();
+      }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
     public async Task PauseAsync_CallsDriverAndUpdatesState()
     {
       // Arrange

--- a/FluentDocker.Tests/Mocks/MockDriverPack.Compose.cs
+++ b/FluentDocker.Tests/Mocks/MockDriverPack.Compose.cs
@@ -270,5 +270,20 @@ namespace FluentDocker.Tests.Mocks
               }));
       return this;
     }
+
+    /// <summary>
+    /// Sets up ContainerDriver.KillAsync to return success.
+    /// </summary>
+    public MockDriverPack SetupContainerKill()
+    {
+      ContainerDriver
+          .Setup(d => d.KillAsync(
+              It.IsAny<DriverContext>(),
+              It.IsAny<string>(),
+              It.IsAny<string>(),
+              It.IsAny<CancellationToken>()))
+          .ReturnsAsync(FluentDocker.Model.Drivers.CommandResponse<Unit>.Ok(Unit.Default));
+      return this;
+    }
   }
 }

--- a/FluentDocker/Services/IContainerService.cs
+++ b/FluentDocker/Services/IContainerService.cs
@@ -77,6 +77,16 @@ namespace FluentDocker.Services
     /// Gets real-time stats from the container.
     /// </summary>
     Task<ContainerStats> GetStatsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Kills the container by sending it a signal (defaults to <c>SIGKILL</c>).
+    /// Unlike <see cref="IServiceAsync.StopAsync"/>, kill does not give the container a
+    /// graceful shutdown period — it is the fast, forceful teardown typically wanted for
+    /// disposable integration-test containers.
+    /// </summary>
+    /// <param name="signal">The signal to send, e.g. <c>SIGKILL</c> or <c>SIGTERM</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task KillAsync(string signal = "SIGKILL", CancellationToken cancellationToken = default);
   }
 
   /// <summary>

--- a/FluentDocker/Services/Impl/ContainerService.cs
+++ b/FluentDocker/Services/Impl/ContainerService.cs
@@ -176,6 +176,28 @@ namespace FluentDocker.Services.Impl
       await ExecuteHooksAsync(ServiceRunningState.Stopped).ConfigureAwait(false);
     }
 
+    public async Task KillAsync(string signal = "SIGKILL", CancellationToken cancellationToken = default)
+    {
+      var driver = _kernel.SysCtl<IContainerDriver>(_driverId);
+      var context = new DriverContext(_driverId);
+
+      UpdateState(ServiceRunningState.Stopping);
+      await ExecuteHooksAsync(ServiceRunningState.Stopping).ConfigureAwait(false);
+
+      var response = await driver.KillAsync(context, _containerId, signal, cancellationToken).ConfigureAwait(false);
+
+      if (!response.Success)
+      {
+        throw new DriverException(
+            $"Failed to kill container '{_name}': {response.Error}",
+            response.ErrorCode,
+            response.ErrorContext);
+      }
+
+      UpdateState(ServiceRunningState.Stopped);
+      await ExecuteHooksAsync(ServiceRunningState.Stopped).ConfigureAwait(false);
+    }
+
     public async Task RemoveAsync(bool force = false, CancellationToken cancellationToken = default)
     {
       var driver = _kernel.SysCtl<IContainerDriver>(_driverId);


### PR DESCRIPTION
Fixes #267

## Request
A friendly `.Kill()` on the container service that maps to `docker kill` (SIGKILL, no grace period), so disposable integration-test containers can be torn down instantly.

## What was missing
The capability already exists at the driver layer — `IContainerDriver.KillAsync(context, id, signal = "SIGKILL", ct)` with Docker CLI, Docker Engine API (`POST /containers/{id}/kill`), and Podman CLI implementations. But `IContainerService` exposed only `Start/Pause/Stop/Remove`; kill was reachable only by dropping down to the kernel/driver directly.

## Change
- `IContainerService.KillAsync(string signal = "SIGKILL", CancellationToken = default)`.
- Implemented in `ContainerService`, mirroring `StopAsync`: resolves the container driver, delegates to `driver.KillAsync`, throws `DriverException` on `!Success`, and transitions to `Stopped`.

No driver/model changes (the plumbing and `ErrorCodes.Container.KillFailed` already exist).

## Tests
`ContainerServiceTests.Operations`: signal pass-through (`SIGTERM`), `SIGKILL` default, and `DriverException` on driver failure. Added a `SetupContainerKill` mock helper.

Full unit suite: **3138 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)