### PR TITLE
feat(#264): add WithInteractive/WithTty/WithEntrypoint to the fluent builder

### DIFF
--- a/FluentDocker.Tests/CoreTests/BuilderTests/BuilderContainerTests.Interactive.cs
+++ b/FluentDocker.Tests/CoreTests/BuilderTests/BuilderContainerTests.Interactive.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentDocker.Builders;
+using FluentDocker.Drivers;
+using Moq;
+using Xunit;
+
+namespace FluentDocker.Tests.CoreTests.BuilderTests
+{
+  /// <summary>
+  /// Tests for interactive/tty/entrypoint builder options (issue #264): keeping a
+  /// short-lived image alive for <c>ExecuteAsync</c> and overriding the entrypoint.
+  /// </summary>
+  public partial class BuilderContainerTests
+  {
+    #region Interactive / Tty / Entrypoint (issue #264)
+
+    [Fact]
+    public async Task UseContainer_WithInteractive_PassesInteractive()
+    {
+      MockPack
+          .SetupContainerCreate()
+          .SetupContainerStart()
+          .SetupContainerInspect(running: true)
+          .SetupContainerStop()
+          .SetupContainerRemove();
+
+      await new Builder()
+          .WithinDriver(DriverId, Kernel)
+          .UseContainer(c => c
+              .UseImage("mcr.microsoft.com/dotnet/sdk:6.0")
+              .WithInteractive())
+          .BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+      MockPack.ContainerDriver.Verify(d => d.CreateAsync(
+          It.IsAny<FluentDocker.Model.Drivers.DriverContext>(),
+          It.Is<ContainerCreateConfig>(cfg => cfg.Interactive == true),
+          It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UseContainer_WithTty_PassesTty()
+    {
+      MockPack
+          .SetupContainerCreate()
+          .SetupContainerStart()
+          .SetupContainerInspect(running: true)
+          .SetupContainerStop()
+          .SetupContainerRemove();
+
+      await new Builder()
+          .WithinDriver(DriverId, Kernel)
+          .UseContainer(c => c
+              .UseImage("alpine")
+              .WithTty())
+          .BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+      MockPack.ContainerDriver.Verify(d => d.CreateAsync(
+          It.IsAny<FluentDocker.Model.Drivers.DriverContext>(),
+          It.Is<ContainerCreateConfig>(cfg => cfg.Tty == true),
+          It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UseContainer_WithEntrypoint_PassesEntrypointTokens()
+    {
+      MockPack
+          .SetupContainerCreate()
+          .SetupContainerStart()
+          .SetupContainerInspect(running: true)
+          .SetupContainerStop()
+          .SetupContainerRemove();
+
+      await new Builder()
+          .WithinDriver(DriverId, Kernel)
+          .UseContainer(c => c
+              .UseImage("alpine")
+              .WithEntrypoint("/bin/sh", "-c"))
+          .BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+      MockPack.ContainerDriver.Verify(d => d.CreateAsync(
+          It.IsAny<FluentDocker.Model.Drivers.DriverContext>(),
+          It.Is<ContainerCreateConfig>(cfg =>
+              cfg.Entrypoint != null &&
+              cfg.Entrypoint.SequenceEqual(new[] { "/bin/sh", "-c" })),
+          It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UseContainer_WithoutInteractive_DefaultsToFalse()
+    {
+      MockPack
+          .SetupContainerCreate()
+          .SetupContainerStart()
+          .SetupContainerInspect(running: true)
+          .SetupContainerStop()
+          .SetupContainerRemove();
+
+      await new Builder()
+          .WithinDriver(DriverId, Kernel)
+          .UseContainer(c => c.UseImage("alpine"))
+          .BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+      MockPack.ContainerDriver.Verify(d => d.CreateAsync(
+          It.IsAny<FluentDocker.Model.Drivers.DriverContext>(),
+          It.Is<ContainerCreateConfig>(cfg =>
+              cfg.Interactive == false && cfg.Tty == false && cfg.Entrypoint == null),
+          It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+  }
+}

--- a/FluentDocker/Builders/ContainerBuilder.cs
+++ b/FluentDocker/Builders/ContainerBuilder.cs
@@ -73,6 +73,9 @@ namespace FluentDocker.Builders
     private bool _readonlyRootfs;
     private string _platform;
     private string _runtime;
+    private bool _interactive;
+    private bool _tty;
+    private string[] _entrypoint;
     private int _waitPollIntervalMs = 500;
     private Services.Impl.ContainerService _pendingService;
     private bool _waitConditionsExecuted;
@@ -118,6 +121,9 @@ namespace FluentDocker.Builders
     }
 
     public IContainerBuilder WithCommand(params string[] command) { _command.AddRange(command); return this; }
+    public IContainerBuilder WithInteractive(bool interactive = true) { _interactive = interactive; return this; }
+    public IContainerBuilder WithTty(bool tty = true) { _tty = tty; return this; }
+    public IContainerBuilder WithEntrypoint(params string[] entrypoint) { _entrypoint = entrypoint; return this; }
     public IContainerBuilder WithVolume(string hostPath, string containerPath) { _volumes[hostPath] = containerPath; return this; }
     public IContainerBuilder WithLabel(string key, string value) { _labels[key] = value; return this; }
     public IContainerBuilder WithWorkingDirectory(string workingDir) { _workingDir = workingDir; return this; }
@@ -437,7 +443,10 @@ namespace FluentDocker.Builders
         Devices = _devices.Count > 0 ? _devices : null,
         ReadonlyRootfs = _readonlyRootfs,
         Platform = _platform,
-        Runtime = _runtime
+        Runtime = _runtime,
+        Interactive = _interactive,
+        Tty = _tty,
+        Entrypoint = _entrypoint?.Length > 0 ? _entrypoint : null
       };
 
       var response = await driver.CreateAsync(context, config, cancellationToken).ConfigureAwait(false);

--- a/FluentDocker/Builders/IContainerBuilder.cs
+++ b/FluentDocker/Builders/IContainerBuilder.cs
@@ -89,6 +89,30 @@ namespace FluentDocker.Builders
     /// <returns>The builder instance for method chaining.</returns>
     IContainerBuilder WithCommand(params string[] command);
 
+    /// <summary>
+    /// Keeps STDIN open on the container (<c>docker run -i</c>). Combined with
+    /// <see cref="WithTty"/>, this keeps an otherwise short-lived image (e.g. an SDK base
+    /// image) alive so commands can be run into it via <c>ExecuteAsync</c>.
+    /// </summary>
+    /// <param name="interactive">Whether to keep STDIN open. Defaults to <c>true</c>.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    IContainerBuilder WithInteractive(bool interactive = true);
+
+    /// <summary>
+    /// Allocates a pseudo-TTY for the container (<c>docker run -t</c>).
+    /// </summary>
+    /// <param name="tty">Whether to allocate a TTY. Defaults to <c>true</c>.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    IContainerBuilder WithTty(bool tty = true);
+
+    /// <summary>
+    /// Overrides the image entrypoint (<c>docker run --entrypoint</c>). Each element is a
+    /// separate token; the first is the executable and the rest are its arguments.
+    /// </summary>
+    /// <param name="entrypoint">The entrypoint executable and arguments.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    IContainerBuilder WithEntrypoint(params string[] entrypoint);
+
     /// <summary>Binds a host path to a container path as a volume mount.</summary>
     /// <param name="hostPath">The absolute path on the host filesystem.</param>
     /// <param name="containerPath">The mount point inside the container.</param>


### PR DESCRIPTION
Fixes #264

## Background
The thread's part 1 (run an existing Dockerfile via the fluent API) is already covered in v3 by `UseImage(... df => df.FromFile(...))`. Part 2 — keeping a short-lived image (e.g. `sdk:6.0`, whose default CMD exits immediately) alive long enough to `ExecuteAsync` into it — was the maintainer's outstanding TODO ("I'll add support for interactive for fluent API") and was still missing in v3.

## Change
Add to `IContainerBuilder`/`ContainerBuilder`:
- `WithInteractive(bool = true)` — keep STDIN open (`-i`)
- `WithTty(bool = true)` — allocate a pseudo-TTY (`-t`)
- `WithEntrypoint(params string[])` — override the entrypoint (`--entrypoint`)

These set `Interactive`/`Tty`/`Entrypoint` on the `ContainerCreateConfig` built in `ExecuteAsync`. **No driver changes needed** — `DockerApiContainerDriver`, `DockerCliContainerDriver` and the Podman CLI driver already consume those config fields.

The `WithCommand("tail","-f","/dev/null")` workaround still works; this adds the first-class idiom the maintainer promised.

## Tests
`BuilderContainerTests.Interactive`: each flag/entrypoint propagates to the driver `ContainerCreateConfig`, and defaults are `false`/`false`/`null` when unset.

Full unit suite: **3139 passed, 0 failed**. `ContainerBuilder.cs` kept under the 500-line limit (496).

🤖 Generated with [Claude Code](https://claude.com/claude-code)