### PR TITLE
feat(#280): add WithBuildContext for in-place Dockerfile builds

### DIFF
--- a/FluentDocker.Tests/CoreTests/BuilderTests/DockerfileBuilderInPlaceTests.cs
+++ b/FluentDocker.Tests/CoreTests/BuilderTests/DockerfileBuilderInPlaceTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentDocker.Builders;
+using FluentDocker.Common;
+using FluentDocker.Drivers;
+using FluentDocker.Model.Drivers;
+using FluentDocker.Tests.Mocks;
+using Moq;
+using Xunit;
+
+namespace FluentDocker.Tests.CoreTests.BuilderTests
+{
+  /// <summary>
+  /// Tests for in-place builds via <c>FromFile(...).WithBuildContext(...)</c> (issue #280):
+  /// an existing Dockerfile must be used in place (passed via <c>--file</c>) without rendering
+  /// or copying a generated Dockerfile into the user's working directory.
+  /// </summary>
+  [Trait("Category", "Unit")]
+  public sealed class DockerfileBuilderInPlaceTests : MockKernelTestBase, IAsyncLifetime
+  {
+    public ValueTask InitializeAsync() => new(InitializeMockKernelAsync());
+
+    private static string NewTempDir()
+    {
+      var dir = Path.Combine(Path.GetTempPath(), "fd280-" + Guid.NewGuid().ToString("N"));
+      Directory.CreateDirectory(dir);
+      return dir;
+    }
+
+    private static void SafeDelete(string dir)
+    {
+      try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+      catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task WithBuildContext_DoesNotLeaveGeneratedDockerfileInContext()
+    {
+      var root = NewTempDir();
+      try
+      {
+        // Dockerfile lives in a sub-directory; build context is the parent (the #280 scenario).
+        var sub = Path.Combine(root, "app");
+        Directory.CreateDirectory(sub);
+        var dockerfile = Path.Combine(sub, "Dockerfile");
+        await File.WriteAllTextAsync(dockerfile, "FROM alpine:3.20\nCMD [\"true\"]\n",
+            TestContext.Current.CancellationToken);
+
+        var contents = await new DockerfileBuilder()
+            .FromFile(dockerfile)
+            .WithBuildContext(root)
+            .ToDockerfileStringAsync();
+
+        // The existing file's contents are returned…
+        Assert.Contains("FROM alpine:3.20", contents);
+        // …and NO generated Dockerfile is written into the build context root.
+        Assert.False(File.Exists(Path.Combine(root, "Dockerfile")),
+            "in-place build must not render a Dockerfile into the build context");
+      }
+      finally { SafeDelete(root); }
+    }
+
+    [Fact]
+    public async Task WithBuildContext_PassesRelativeDockerfileNameAndContextToDriver()
+    {
+      var root = NewTempDir();
+      try
+      {
+        var sub = Path.Combine(root, "app");
+        Directory.CreateDirectory(sub);
+        var dockerfile = Path.Combine(sub, "Dockerfile");
+        await File.WriteAllTextAsync(dockerfile, "FROM alpine:3.20\n",
+            TestContext.Current.CancellationToken);
+
+        ImageBuildConfig captured = null;
+        MockPack.ImageDriver
+            .Setup(d => d.BuildAsync(
+                It.IsAny<DriverContext>(),
+                It.IsAny<ImageBuildConfig>(),
+                It.IsAny<IProgress<ImageBuildProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<DriverContext, ImageBuildConfig, IProgress<ImageBuildProgress>, CancellationToken>(
+                (_, cfg, _, _) => captured = cfg)
+            .ReturnsAsync(CommandResponse<ImageBuildResult>.Ok(
+                new ImageBuildResult { ImageId = "sha256:deadbeef" }));
+
+        await new Builder()
+            .WithinDriver(DriverId, Kernel)
+            .UseImage("inplace-img:latest", df => df
+                .FromFile(dockerfile)
+                .WithBuildContext(root))
+            .BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured);
+        Assert.Equal(Path.GetFullPath(root), captured.BuildContext);
+        Assert.Equal("app/Dockerfile", captured.DockerfileName);
+      }
+      finally { SafeDelete(root); }
+    }
+
+    [Fact]
+    public async Task WithBuildContext_DockerfileOutsideContext_Throws()
+    {
+      var root = NewTempDir();
+      try
+      {
+        var dockerfile = Path.Combine(root, "Dockerfile");
+        await File.WriteAllTextAsync(dockerfile, "FROM alpine\n", TestContext.Current.CancellationToken);
+        var otherContext = Path.Combine(root, "elsewhere");
+        Directory.CreateDirectory(otherContext);
+
+        var builder = new DockerfileBuilder()
+            .FromFile(dockerfile)
+            .WithBuildContext(otherContext);
+
+        await Assert.ThrowsAsync<FluentDockerException>(() => builder.ToDockerfileStringAsync());
+      }
+      finally { SafeDelete(root); }
+    }
+
+    [Fact]
+    public async Task WithoutBuildContext_NormalRenderPath_StillProducesDockerfile()
+    {
+      // Regression guard: the default (non-in-place) path is unaffected.
+      var contents = await new DockerfileBuilder()
+          .UseParent("alpine:3.20")
+          .Run("echo hi")
+          .ToDockerfileStringAsync();
+
+      Assert.Contains("FROM alpine:3.20", contents);
+      Assert.Contains("RUN echo hi", contents);
+    }
+  }
+}

--- a/FluentDocker/Builders/DockerfileBuilder.cs
+++ b/FluentDocker/Builders/DockerfileBuilder.cs
@@ -21,7 +21,19 @@ namespace FluentDocker.Builders
     private readonly FileBuilderConfig _config = new();
     private readonly ImageBuilder _parent;
     private TemplateString _workingFolder;
+    private TemplateString _buildContext;
     private string _lastContents;
+    private string _preparedDockerfileName;
+
+    /// <summary>
+    /// When an in-place build context is used (see <see cref="WithBuildContext"/>), this is
+    /// the name of the existing Dockerfile relative to the build context, suitable for the
+    /// driver's <c>--file</c> argument. <c>null</c> for the default (rendered) build path.
+    /// </summary>
+    internal string PreparedDockerfileName => _preparedDockerfileName;
+
+    private bool IsInPlaceBuild =>
+        _buildContext != null && !string.IsNullOrEmpty(_config.UseFile?.Rendered);
 
     /// <summary>
     /// Creates a standalone DockerfileBuilder for generating Dockerfile content.
@@ -45,9 +57,43 @@ namespace FluentDocker.Builders
     /// <returns>Working directory path</returns>
     internal async Task<string> PrepareBuildAsync()
     {
+      if (IsInPlaceBuild)
+        return PrepareInPlaceBuild();
+
       await CopyToWorkDirAsync(_workingFolder).ConfigureAwait(false);
       RenderDockerfile(_workingFolder);
       return _workingFolder;
+    }
+
+    /// <summary>
+    /// Prepares an in-place build: uses an existing Dockerfile within the caller-provided
+    /// build context without copying or rendering anything, so no generated Dockerfile is
+    /// left behind (issue #280).
+    /// </summary>
+    private string PrepareInPlaceBuild()
+    {
+      var context = _buildContext.Rendered;
+      if (string.IsNullOrEmpty(context) || !Directory.Exists(context))
+        throw new FluentDockerException(
+            $"WithBuildContext path '{context}' does not exist.");
+
+      var dockerfilePath = _config.UseFile.Rendered;
+      if (string.IsNullOrEmpty(dockerfilePath) || !File.Exists(dockerfilePath))
+        throw new FluentDockerException(
+            $"FromFile path '{dockerfilePath}' does not exist.");
+
+      // The Dockerfile must live inside the build context so docker/podman (and the
+      // Engine API context tarball) can reference it via --file relative to the context.
+      var fullContext = Path.GetFullPath(context);
+      var fullDockerfile = Path.GetFullPath(dockerfilePath);
+      var relative = Path.GetRelativePath(fullContext, fullDockerfile);
+      if (relative.StartsWith("..", StringComparison.Ordinal) || Path.IsPathRooted(relative))
+        throw new FluentDockerException(
+            $"The Dockerfile '{fullDockerfile}' must reside inside the build context '{fullContext}'.");
+
+      _preparedDockerfileName = relative.Replace('\\', '/');
+      _lastContents = File.ReadAllText(fullDockerfile);
+      return fullContext;
     }
 
     /// <summary>
@@ -101,6 +147,22 @@ namespace FluentDocker.Builders
     public DockerfileBuilder WorkingFolder(string workingFolder)
     {
       _workingFolder = workingFolder;
+      return this;
+    }
+
+    /// <summary>
+    /// Builds an existing Dockerfile (set via <see cref="FromFile"/>) in place, using
+    /// <paramref name="contextPath"/> as the build context. The existing Dockerfile is
+    /// passed to the engine via <c>--file</c> instead of being copied or rendered, so no
+    /// generated <c>Dockerfile</c> is left in your working directory (issue #280).
+    /// </summary>
+    /// <param name="contextPath">
+    /// The build context directory. The Dockerfile passed to <see cref="FromFile"/> must
+    /// reside inside this directory (it may be in a sub-directory).
+    /// </param>
+    public DockerfileBuilder WithBuildContext(string contextPath)
+    {
+      _buildContext = contextPath;
       return this;
     }
 

--- a/FluentDocker/Builders/ImageBuilder.cs
+++ b/FluentDocker/Builders/ImageBuilder.cs
@@ -296,6 +296,7 @@ namespace FluentDocker.Builders
       var buildConfig = new ImageBuildConfig
       {
         BuildContext = buildContext,
+        DockerfileName = _dockerfileBuilder.PreparedDockerfileName,
         Tags = [.. _tags.Select(t => $"{_imageName}:{t}")],
         BuildArgs = _buildArgs,
         Labels = _labels,


### PR DESCRIPTION
Fixes #280

## Problem
When building from an existing Dockerfile, FluentDocker always rendered a copy named `Dockerfile` into the working folder. The reporter set the working folder to their own directory (the build context lives a level above the Dockerfile), so the generated `Dockerfile` was left in their tree and easily committed by mistake. They asked for a `WithBuildContext` method and to *not* copy/modify the Dockerfile — just use it and pass build args.

## Fix
`DockerfileBuilder.WithBuildContext(string contextPath)`. Combined with `FromFile(existing)`, the build runs **in place**:
- nothing is copied or rendered (no leftover file),
- the existing Dockerfile is passed via the engine's `--file` argument, computed **relative to the context**,
- `contextPath` becomes the build context.

The driver layer already honors `ImageBuildConfig.DockerfileName` (Docker CLI `--file`, Podman `-f`, Docker Engine API `dockerfile=`); `ImageBuilder.ExecuteAsync` now sets it from the prepared in-place name. If the Dockerfile is outside the context (an engine requirement for the context tarball), a clear `FluentDockerException` is thrown.

```csharp
new Builder().WithinDriver(driverId, kernel)
  .UseImage("myimg:latest", df => df
      .FromFile("/repo/app/Dockerfile")
      .WithBuildContext("/repo"))     // build context = /repo, --file app/Dockerfile
  .BuildAsync();
```

The default (rendered) build path is unchanged.

## Tests
`DockerfileBuilderInPlaceTests`: in-place build leaves no `Dockerfile` in the context; the mock image driver receives `DockerfileName == "app/Dockerfile"` and the full context path; a Dockerfile outside the context throws; and the normal render path still produces a Dockerfile.

Full unit suite: **3139 passed, 0 failed**. `DockerfileBuilder.cs` kept under the 500-line limit (493).

🤖 Generated with [Claude Code](https://claude.com/claude-code)