### PR TITLE
feat(#305): attach to an existing compose project without running up

### DIFF
--- a/FluentDocker.Tests/CoreTests/BuilderTests/BuilderComposeTests.Connect.cs
+++ b/FluentDocker.Tests/CoreTests/BuilderTests/BuilderComposeTests.Connect.cs
@@ -1,0 +1,63 @@
+using System.Threading.Tasks;
+using FluentDocker.Builders;
+using FluentDocker.Common;
+using FluentDocker.Drivers;
+using FluentDocker.Model.Drivers;
+using FluentDocker.Tests.Mocks;
+using Moq;
+using Xunit;
+
+namespace FluentDocker.Tests.CoreTests.BuilderTests
+{
+  /// <summary>
+  /// Tests for attaching to an existing compose project (issue #305): ConnectToExisting()
+  /// must return a usable IComposeService without running `docker compose up`.
+  /// </summary>
+  public partial class BuilderComposeTests
+  {
+    [Fact]
+    public async Task ConnectToExisting_DoesNotRunUp_AndReturnsService()
+    {
+      var (kernel, mockPack) = await MockKernelBuilderExtensions.CreateWithMockDriverAsync("docker");
+      try
+      {
+        await using var results = await new Builder()
+            .WithinDriver("docker", kernel)
+            .UseCompose(c => c
+                .WithProjectName("existing-proj")
+                .ConnectToExisting())
+            .BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // `up` must never be invoked when attaching to an existing project.
+        mockPack.ComposeDriver.Verify(d => d.UpAsync(
+            It.IsAny<DriverContext>(),
+            It.IsAny<ComposeUpConfig>(),
+            It.IsAny<System.Threading.CancellationToken>()), Times.Never);
+
+        Assert.Single(results.ComposeServices);
+        Assert.Equal("existing-proj", results.ComposeServices[0].ProjectName);
+      }
+      finally { kernel.Dispose(); }
+    }
+
+    [Fact]
+    public async Task ConnectToExisting_WithoutProjectOrFiles_Throws()
+    {
+      var (kernel, mockPack) = await MockKernelBuilderExtensions.CreateWithMockDriverAsync("docker");
+      try
+      {
+        await Assert.ThrowsAsync<FluentDockerException>(async () =>
+            await new Builder()
+                .WithinDriver("docker", kernel)
+                .UseCompose(c => c.ConnectToExisting())
+                .BuildAsync(cancellationToken: TestContext.Current.CancellationToken));
+
+        mockPack.ComposeDriver.Verify(d => d.UpAsync(
+            It.IsAny<DriverContext>(),
+            It.IsAny<ComposeUpConfig>(),
+            It.IsAny<System.Threading.CancellationToken>()), Times.Never);
+      }
+      finally { kernel.Dispose(); }
+    }
+  }
+}

--- a/FluentDocker.Tests/CoreTests/Service/ComposeServiceRefreshStateTests.cs
+++ b/FluentDocker.Tests/CoreTests/Service/ComposeServiceRefreshStateTests.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentDocker.Drivers;
+using FluentDocker.Kernel;
+using FluentDocker.Model.Drivers;
+using FluentDocker.Services;
+using FluentDocker.Services.Impl;
+using FluentDocker.Tests.Mocks;
+using Moq;
+using Xunit;
+
+namespace FluentDocker.Tests.CoreTests.Service
+{
+  /// <summary>
+  /// Tests for ComposeService.RefreshStateAsync (issue #305): aggregate state is derived
+  /// from the live per-service status returned by `docker compose ps`.
+  /// </summary>
+  [Trait("Category", "Unit")]
+  public class ComposeServiceRefreshStateTests
+  {
+    private static ComposeService CreateService(FluentDockerKernel kernel) =>
+        new(kernel, "docker", ["docker-compose.yml"], "test-project");
+
+    private static void SetupList(MockDriverPack pack, params ComposeServiceInfo[] services)
+    {
+      pack.ComposeDriver
+          .Setup(d => d.ListAsync(
+              It.IsAny<DriverContext>(),
+              It.IsAny<ComposeListConfig>(),
+              It.IsAny<CancellationToken>()))
+          .ReturnsAsync(CommandResponse<IList<ComposeServiceInfo>>.Ok(services));
+    }
+
+    [Fact]
+    public async Task RefreshStateAsync_AnyRunning_SetsRunning()
+    {
+      var mockPack = new MockDriverPack();
+      SetupList(mockPack,
+          new ComposeServiceInfo { Name = "web", State = "running" },
+          new ComposeServiceInfo { Name = "db", State = "exited" });
+
+      var kernel = await MockKernelBuilderExtensions.CreateWithMockDriverAsync("docker", mockPack);
+      try
+      {
+        var service = CreateService(kernel);
+        await service.RefreshStateAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(ServiceRunningState.Running, service.State);
+      }
+      finally { kernel.Dispose(); }
+    }
+
+    [Fact]
+    public async Task RefreshStateAsync_AllStopped_SetsStopped()
+    {
+      var mockPack = new MockDriverPack();
+      SetupList(mockPack,
+          new ComposeServiceInfo { Name = "web", State = "exited" },
+          new ComposeServiceInfo { Name = "db", State = "exited" });
+
+      var kernel = await MockKernelBuilderExtensions.CreateWithMockDriverAsync("docker", mockPack);
+      try
+      {
+        var service = CreateService(kernel);
+        await service.RefreshStateAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(ServiceRunningState.Stopped, service.State);
+      }
+      finally { kernel.Dispose(); }
+    }
+
+    [Fact]
+    public async Task RefreshStateAsync_NoServices_SetsUnknown()
+    {
+      var mockPack = new MockDriverPack();
+      SetupList(mockPack);
+
+      var kernel = await MockKernelBuilderExtensions.CreateWithMockDriverAsync("docker", mockPack);
+      try
+      {
+        var service = CreateService(kernel);
+        await service.RefreshStateAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(ServiceRunningState.Unknown, service.State);
+      }
+      finally { kernel.Dispose(); }
+    }
+  }
+}

--- a/FluentDocker/Builders/BuilderInterfaces.cs
+++ b/FluentDocker/Builders/BuilderInterfaces.cs
@@ -197,5 +197,16 @@ namespace FluentDocker.Builders
     /// <param name="profiles">Profile names to activate.</param>
     /// <returns>The builder for fluent chaining.</returns>
     IComposeBuilder WithProfiles(params string[] profiles);
+
+    /// <summary>
+    /// Attaches to an already-running compose project instead of running <c>docker compose up</c>.
+    /// On build, the resulting <see cref="Services.IComposeService"/> is returned without starting
+    /// or modifying the project, so it can be inspected (e.g. <c>ListServicesAsync</c>,
+    /// <c>RefreshStateAsync</c>, logs) and later managed. Requires <see cref="WithProjectName"/>
+    /// and/or <see cref="WithComposeFile"/> to identify the project.
+    /// </summary>
+    /// <param name="connect">True to attach to an existing project; false for normal up behavior.</param>
+    /// <returns>The builder for fluent chaining.</returns>
+    IComposeBuilder ConnectToExisting(bool connect = true);
   }
 }

--- a/FluentDocker/Builders/InternalBuilders.cs
+++ b/FluentDocker/Builders/InternalBuilders.cs
@@ -172,6 +172,7 @@ namespace FluentDocker.Builders
     private bool _wait;
     private int? _timeout;
     private int? _waitTimeout;
+    private bool _attachToExisting;
     private readonly List<string> _services = [];
 
     public IComposeBuilder WithComposeFile(string path) { _composeFiles.Add(path); return this; }
@@ -228,11 +229,24 @@ namespace FluentDocker.Builders
     }
 
     public IComposeBuilder WithProfiles(params string[] profiles) { _profiles.AddRange(profiles); return this; }
+    public IComposeBuilder ConnectToExisting(bool connect = true) { _attachToExisting = connect; return this; }
 
     public async Task<IServiceAsync> ExecuteAsync(CancellationToken cancellationToken)
     {
       var driver = _kernel.SysCtl<Drivers.IComposeDriver>(_driverId);
       var context = new DriverContext(_driverId);
+
+      // Attach to an already-running project: do NOT run `compose up`, just hand back a
+      // service bound to the existing project (issue #305).
+      if (_attachToExisting)
+      {
+        if (string.IsNullOrEmpty(_projectName) && _composeFiles.Count == 0)
+          throw new FluentDockerException(
+              "ConnectToExisting requires WithProjectName and/or WithComposeFile to identify the project.");
+
+        return new Services.Impl.ComposeService(
+            _kernel, _driverId, _composeFiles, _projectName, _removeVolumes, _removeImages);
+      }
 
       var config = new Drivers.ComposeUpConfig
       {

--- a/FluentDocker/Services/IComposeService.cs
+++ b/FluentDocker/Services/IComposeService.cs
@@ -39,6 +39,16 @@ namespace FluentDocker.Services
     /// Scales a service to the specified number of instances.
     /// </summary>
     Task ScaleAsync(string service, int replicas, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Refreshes <see cref="IServiceAsync.State"/> by querying the live per-service status
+    /// (<c>docker compose ps</c>). Useful after attaching to an existing project (see
+    /// <c>ConnectToExisting</c>) so the aggregate state reflects what the daemon reports
+    /// rather than the assumed default. The state becomes <c>Running</c> if any service is
+    /// running, <c>Stopped</c> if all are stopped/exited, or <c>Unknown</c> if no services exist.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RefreshStateAsync(CancellationToken cancellationToken = default);
   }
 }
 

--- a/FluentDocker/Services/Impl/ComposeService.cs
+++ b/FluentDocker/Services/Impl/ComposeService.cs
@@ -161,6 +161,30 @@ namespace FluentDocker.Services.Impl
       }
     }
 
+    public async Task RefreshStateAsync(CancellationToken cancellationToken = default)
+    {
+      var services = await ListServicesAsync(cancellationToken).ConfigureAwait(false);
+
+      if (services == null || services.Count == 0)
+      {
+        UpdateState(ServiceRunningState.Unknown);
+        return;
+      }
+
+      var anyRunning = false;
+      foreach (var s in services)
+      {
+        if (!string.IsNullOrEmpty(s.State) &&
+            s.State.Contains("running", StringComparison.OrdinalIgnoreCase))
+        {
+          anyRunning = true;
+          break;
+        }
+      }
+
+      UpdateState(anyRunning ? ServiceRunningState.Running : ServiceRunningState.Stopped);
+    }
+
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
       var driver = _kernel.SysCtl<IComposeDriver>(_driverId);


### PR DESCRIPTION
Fixes #305

## Request
Attach to an already-running compose project (without mutating it) and read its status. In v2 the status showed `Unknown` until a Start/Stop was issued.

## What was missing
v3 can already *read* live status via `IComposeService.ListServicesAsync` (`docker compose -p <project> ps --format json`) with no mutation. But the only way to get an `IComposeService` was the fluent `ComposeBuilder`, which always runs `UpAsync`; and the aggregate `ComposeService.State` was hardcoded to `Running`.

## Change
- **`IComposeBuilder.ConnectToExisting(bool = true)`** — on `BuildAsync()`, returns a `ComposeService` bound to the project **without** calling `UpAsync`. Requires `WithProjectName` and/or `WithComposeFile`; throws a clear `FluentDockerException` otherwise.
- **`IComposeService.RefreshStateAsync(ct)`** — updates aggregate `State` from live `docker compose ps`: `Running` if any service runs, `Stopped` if all are stopped/exited, `Unknown` if none. Addresses the original "Unknown until a command" complaint.

```csharp
await using var results = await new Builder()
    .WithinDriver(driverId, kernel)
    .UseCompose(c => c.WithProjectName("myproj").ConnectToExisting())
    .BuildAsync();
var svc = results.ComposeServices[0];
await svc.RefreshStateAsync();   // reflects real daemon state
```

## Tests
`BuilderComposeTests.Connect`: attach does not invoke `UpAsync` and yields a service bound to the project; missing project/files throws. `ComposeServiceRefreshStateTests`: running/stopped/empty state mapping.

Full unit suite: **3140 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)