### PR TITLE
docs(#197): show how to read container info (created date, config, host port)

### DIFF
--- a/docs/containers.md
+++ b/docs/containers.md
@@ -11,7 +11,7 @@ Complete guide to creating, configuring, and managing containers with FluentDock
 ## Step by Step
 
 - Basics: [Kernel Setup](#kernel-setup), [Container Lifecycle](#container-lifecycle), [Port Exposure](#port-exposure), [Environment Variables](#environment-variables)
-- Intermediate: [Wait Strategies](#wait-strategies), [Execute Commands](#execute-commands), [Container Logs](#container-logs), [Cleanup and Dispose Behavior](#cleanup-and-dispose-behavior)
+- Intermediate: [Wait Strategies](#wait-strategies), [Execute Commands](#execute-commands), [Container Logs](#container-logs), [Inspecting Container Info](#inspecting-container-info), [Cleanup and Dispose Behavior](#cleanup-and-dispose-behavior)
 - Advanced: [Resource Limits](#resource-limits), [Advanced Container Options](#advanced-container-options), [Container Existence Behavior](#container-existence-behavior), [File Operations](#file-operations)
 
 ## Kernel Setup
@@ -371,6 +371,37 @@ using var results = new Builder()
 var container = results.Containers.First();
 var config = container.GetConfiguration(fresh: true);
 Console.WriteLine($"ID: {config.Id}, Name: {config.Name}, State: {config.State.Status}");
+```
+
+### Inspecting Container Info
+
+`GetConfiguration(fresh: true)` (or the async `GetConfigurationAsync()`) returns the full
+inspected `Container`, so you can read the creation time, the resolved image config,
+environment, exposed ports, and labels without shelling out to `docker inspect`:
+
+```csharp
+var config = container.GetConfiguration(fresh: true);
+
+Console.WriteLine($"Created:    {config.Created:O}");
+Console.WriteLine($"Image:      {config.Config.Image}");
+Console.WriteLine($"WorkingDir: {config.Config.WorkingDir}");
+
+foreach (var env in config.Config.Env ?? Array.Empty<string>())
+    Console.WriteLine($"Env:     {env}");
+
+foreach (var port in config.Config.ExposedPorts?.Keys ?? Enumerable.Empty<string>())
+    Console.WriteLine($"Exposed: {port}");
+
+foreach (var (key, value) in config.Config.Labels ?? new Dictionary<string, string>())
+    Console.WriteLine($"Label:   {key}={value}");
+```
+
+To get the **host** port a container port is mapped to, use `ToHostExposedEndpoint`
+(see [Port Exposure](#port-exposure)):
+
+```csharp
+var endpoint = container.ToHostExposedEndpoint("80/tcp"); // e.g. 127.0.0.1:49162
+Console.WriteLine($"Reachable at {endpoint.Address}:{endpoint.Port}");
 ```
 
 ## Resource Limits


### PR DESCRIPTION
Fixes #197

## Request
A docs section on retrieving "various pieces of container info" — the host port (cross-referencing #196), the container `Created` date, and general config.

## What was missing
The v3 API already exposes all of this (`GetConfiguration()`/`GetConfigurationAsync()` return the full inspected `Container`; `ToHostExposedEndpoint` gives the host port). But the docs only demonstrated `Id`/`Name`/`State.Status`.

## Change (docs only)
Add an **"Inspecting Container Info"** subsection to `docs/containers.md` showing how to read:
- `config.Created` (creation time)
- `config.Config.Image` / `WorkingDir`
- `config.Config.Env`, `ExposedPorts`, `Labels`

…and a cross-reference to `ToHostExposedEndpoint("80/tcp")` for the mapped **host** port (tying in #196). Also added the subsection to the Step-by-Step index for discoverability.

No source changes — the API already exists. `docs/containers.md` stays under the 600-line limit (529).

🤖 Generated with [Claude Code](https://claude.com/claude-code)