### PR TITLE
feat(#315): drive a custom docker-compatible CLI (finch/nerdctl)

### DIFF
--- a/FluentDocker.Tests/CoreTests/Driver/Docker/DockerBinariesResolverCustomBinaryTests.cs
+++ b/FluentDocker.Tests/CoreTests/Driver/Docker/DockerBinariesResolverCustomBinaryTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using FluentDocker.Drivers.Docker.Cli.Binary;
+using FluentDocker.Model.Common;
+using Xunit;
+
+namespace FluentDocker.Tests.CoreTests.Driver.Docker
+{
+  /// <summary>
+  /// Unit tests for resolving a docker-compatible CLI other than "docker"
+  /// (issue #315): finch/nerdctl support via BinaryConfiguration.BinaryName.
+  /// </summary>
+  [Trait("Category", "Unit")]
+  public sealed class DockerBinariesResolverCustomBinaryTests : IDisposable
+  {
+    private readonly string _tempDir;
+
+    public DockerBinariesResolverCustomBinaryTests()
+    {
+      _tempDir = Path.Combine(Path.GetTempPath(), $"fd315_{Guid.NewGuid():N}");
+      Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+      try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); }
+      catch { /* best effort */ }
+      GC.SuppressFinalize(this);
+    }
+
+    private string CreateFakeBinary(string name)
+    {
+      var file = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? $"{name}.exe" : name;
+      var path = Path.Combine(_tempDir, file);
+      File.WriteAllText(path, "fake");
+      return path;
+    }
+
+    [Fact]
+    public void CustomBinary_Finch_ResolvedAsMainDockerClient()
+    {
+      CreateFakeBinary("finch");
+
+      var resolver = new DockerBinariesResolver(new BinaryConfiguration
+      {
+        BinaryName = "finch",
+        SearchPaths = [_tempDir]
+      });
+
+      Assert.NotNull(resolver.MainDockerClient);
+      Assert.Equal(DockerBinaryType.DockerClient, resolver.MainDockerClient.Type);
+      Assert.Equal(_tempDir, resolver.MainDockerClient.Path);
+      // ResolveBinaryPath("docker") returns the configured engine's binary.
+      Assert.Contains("finch", resolver.ResolveBinaryPath("docker"));
+    }
+
+    [Fact]
+    public void CustomBinary_Nerdctl_ResolvedAsMainDockerClient()
+    {
+      CreateFakeBinary("nerdctl");
+
+      var resolver = new DockerBinariesResolver(new BinaryConfiguration
+      {
+        BinaryName = "nerdctl",
+        SearchPaths = [_tempDir]
+      });
+
+      Assert.NotNull(resolver.MainDockerClient);
+      Assert.Contains("nerdctl", resolver.MainDockerClient.FqPath);
+    }
+
+    [Fact]
+    public void CustomBinary_WhenMissing_Throws()
+    {
+      // BinaryName is finch but only a docker binary is present -> not found.
+      CreateFakeBinary("docker");
+
+      Assert.Throws<FluentDocker.Common.FluentDockerException>(() =>
+          new DockerBinariesResolver(new BinaryConfiguration
+          {
+            BinaryName = "finch",
+            SearchPaths = [_tempDir]
+          }));
+    }
+
+    [Fact]
+    public void DefaultBinaryName_IsDocker()
+    {
+      Assert.Equal("docker", new BinaryConfiguration().BinaryName);
+    }
+
+    [Fact]
+    public void Docker_StillResolves_WhenBinaryNameDefaulted()
+    {
+      CreateFakeBinary("docker");
+
+      var resolver = new DockerBinariesResolver(new BinaryConfiguration
+      {
+        SearchPaths = [_tempDir] // BinaryName defaults to "docker"
+      });
+
+      Assert.NotNull(resolver.MainDockerClient);
+      Assert.Equal(DockerBinaryType.DockerClient, resolver.MainDockerClient.Type);
+    }
+  }
+}

--- a/FluentDocker.Tests/CoreTests/Driver/Docker/DockerBinariesResolverTests.cs
+++ b/FluentDocker.Tests/CoreTests/Driver/Docker/DockerBinariesResolverTests.cs
@@ -96,7 +96,7 @@ namespace FluentDocker.Tests.CoreTests.Driver.Docker
             BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(method);
 
-        var result = method.Invoke(instance, [sudo, password, paths]);
+        var result = method.Invoke(instance, [sudo, password, "docker", paths]);
         return (IEnumerable<DockerBinary>)result;
       }
       finally

--- a/FluentDocker/Drivers/Docker/Cli/Binary/BinaryConfiguration.cs
+++ b/FluentDocker/Drivers/Docker/Cli/Binary/BinaryConfiguration.cs
@@ -30,6 +30,13 @@ namespace FluentDocker.Drivers.Docker.Cli.Binary
     public string[] SearchPaths { get; set; }
 
     /// <summary>
+    /// Gets or sets the name of the client binary to resolve and invoke.
+    /// Defaults to <c>docker</c>; set to a docker-compatible CLI such as
+    /// <c>finch</c> or <c>nerdctl</c> to drive that engine.
+    /// </summary>
+    public string BinaryName { get; set; } = "docker";
+
+    /// <summary>
     /// Creates a new instance with default settings.
     /// </summary>
     public BinaryConfiguration()

--- a/FluentDocker/Drivers/Docker/Cli/Binary/DockerBinariesResolver.cs
+++ b/FluentDocker/Drivers/Docker/Cli/Binary/DockerBinariesResolver.cs
@@ -40,6 +40,7 @@ namespace FluentDocker.Drivers.Docker.Cli.Binary
       Binaries = [.. ResolveFromPaths(
           _configuration.Sudo,
           _configuration.SudoPassword,
+          _configuration.BinaryName,
           _configuration.SearchPaths)];
 
       MainDockerClient = Binaries.FirstOrDefault(x => x.Type == DockerBinaryType.DockerClient);
@@ -123,9 +124,13 @@ namespace FluentDocker.Drivers.Docker.Cli.Binary
           : $"sudo -S {binary.FqPath}";
     }
 
-    private IEnumerable<DockerBinary> ResolveFromPaths(SudoMechanism sudo, string password, params string[] paths)
+    private IEnumerable<DockerBinary> ResolveFromPaths(
+        SudoMechanism sudo, string password, string binaryName, params string[] paths)
     {
       var isWindows = IsWindows();
+      var clientName = string.IsNullOrWhiteSpace(binaryName) ? "docker" : binaryName;
+      var isDocker = string.Equals(clientName, "docker", StringComparison.OrdinalIgnoreCase);
+
       if (paths == null || paths.Length == 0)
       {
         var envpaths = Environment.GetEnvironmentVariable("PATH")?.Split(isWindows ? ';' : ':');
@@ -134,6 +139,11 @@ namespace FluentDocker.Drivers.Docker.Cli.Binary
 
       if (paths == null || paths.Length == 0)
         return [];
+
+      // The resolved client binary always maps to DockerClient so MainDockerClient is
+      // found, even for docker-compatible CLIs (finch, nerdctl) whose name does not
+      // translate to a known DockerBinaryType.
+      var clientFile = isWindows ? $"{clientName}.exe" : clientName;
 
       var list = new List<DockerBinary>();
       foreach (var path in paths)
@@ -147,25 +157,28 @@ namespace FluentDocker.Drivers.Docker.Cli.Binary
 
           if (isWindows)
           {
-            list.AddRange(from file in Directory.GetFiles(path, "docker*.*")
-                          let f = Path.GetFileName(file.ToLower())
-                          where f != null && f.Equals("docker.exe", StringComparison.Ordinal)
-                          select new DockerBinary(path, f, sudo, password));
+            list.AddRange(from file in Directory.GetFiles(path, $"{clientName}*.*")
+                          let f = Path.GetFileName(file)
+                          where f != null && f.Equals(clientFile, StringComparison.OrdinalIgnoreCase)
+                          select new DockerBinary(path, f, sudo, password, DockerBinaryType.DockerClient));
 
-            var dockercli = Path.GetFullPath(Path.Combine(path, "..\\.."));
-            if (File.Exists(Path.Combine(dockercli, "dockercli.exe")))
+            // Docker Desktop's dockercli.exe is docker-specific; skip for custom binaries.
+            if (isDocker)
             {
-              list.Add(new DockerBinary(dockercli, "dockercli.exe", sudo, password));
+              var dockercli = Path.GetFullPath(Path.Combine(path, "..\\.."));
+              if (File.Exists(Path.Combine(dockercli, "dockercli.exe")))
+              {
+                list.Add(new DockerBinary(dockercli, "dockercli.exe", sudo, password));
+              }
             }
 
             continue;
           }
 
-          list.AddRange(from file in Directory.GetFiles(path, "docker*")
+          list.AddRange(from file in Directory.GetFiles(path, $"{clientName}*")
                         let f = Path.GetFileName(file)
-                        let f2 = f.ToLower()
-                        where f2.Equals("docker", StringComparison.Ordinal)
-                        select new DockerBinary(path, f, sudo, password));
+                        where f.Equals(clientFile, StringComparison.Ordinal)
+                        select new DockerBinary(path, f, sudo, password, DockerBinaryType.DockerClient));
         }
         catch (Exception e)
         {

--- a/FluentDocker/Drivers/Docker/Cli/DockerCliDriverPack.cs
+++ b/FluentDocker/Drivers/Docker/Cli/DockerCliDriverPack.cs
@@ -62,9 +62,11 @@ namespace FluentDocker.Drivers.Docker.Cli
       {
         Sudo = context.Sudo,
         SudoPassword = context.SudoPassword,
-        DefaultShell = context.DefaultShell
+        DefaultShell = context.DefaultShell,
+        BinaryName = string.IsNullOrWhiteSpace(context.BinaryName) ? "docker" : context.BinaryName,
+        SearchPaths = context.SearchPaths
       };
-      _binaryResolver = new DockerBinariesResolver(binaryConfig);
+      _binaryResolver = new DockerBinariesResolver(binaryConfig, context.LoggerFactory);
 
       // Create and initialize all driver components with binary resolver
       _containerDriver = new DockerCliContainerDriver(_binaryResolver);

--- a/FluentDocker/Kernel/DockerCliDriverBuilder.cs
+++ b/FluentDocker/Kernel/DockerCliDriverBuilder.cs
@@ -16,6 +16,8 @@ namespace FluentDocker.Kernel
     private bool _isDefault;
     private SudoMechanism _sudo = SudoMechanism.None;
     private string _sudoPassword;
+    private string _binaryName;
+    private string[] _searchPaths;
 
     public IDockerCliDriverBuilder AtHost(string host)
     {
@@ -42,6 +44,13 @@ namespace FluentDocker.Kernel
       return this;
     }
 
+    public IDockerCliDriverBuilder WithBinary(string binaryName, params string[] searchPaths)
+    {
+      _binaryName = binaryName;
+      _searchPaths = searchPaths is { Length: > 0 } ? searchPaths : null;
+      return this;
+    }
+
     internal KernelBuilder.DriverConfiguration Build()
     {
       var context = new DriverContext(_driverId)
@@ -50,6 +59,8 @@ namespace FluentDocker.Kernel
         CertificatePath = _certificatePath,
         Sudo = _sudo,
         SudoPassword = _sudoPassword,
+        BinaryName = _binaryName,
+        SearchPaths = _searchPaths,
       };
 
       return new KernelBuilder.DriverConfiguration

--- a/FluentDocker/Kernel/IDockerCliDriverBuilder.cs
+++ b/FluentDocker/Kernel/IDockerCliDriverBuilder.cs
@@ -31,5 +31,16 @@ namespace FluentDocker.Kernel
     /// <param name="mechanism">Sudo mechanism to use</param>
     /// <param name="password">Password when using <see cref="SudoMechanism.Password"/></param>
     IDockerCliDriverBuilder WithSudo(SudoMechanism mechanism, string password = null);
+
+    /// <summary>
+    /// Drives a docker-compatible CLI other than <c>docker</c> (best-effort) — for example
+    /// <c>finch</c> or <c>nerdctl</c> — without aliasing it to <c>docker</c>. Note that some
+    /// engines differ on a few global flags (e.g. <c>-H</c>/<c>--tlsverify</c>).
+    /// </summary>
+    /// <param name="binaryName">The client binary name, e.g. "finch" or "nerdctl".</param>
+    /// <param name="searchPaths">
+    /// Optional directories to search for the binary. When omitted, <c>PATH</c> is used.
+    /// </param>
+    IDockerCliDriverBuilder WithBinary(string binaryName, params string[] searchPaths);
   }
 }

--- a/FluentDocker/Model/Drivers/DriverContext.cs
+++ b/FluentDocker/Model/Drivers/DriverContext.cs
@@ -65,6 +65,19 @@ namespace FluentDocker.Model.Drivers
     public string DefaultShell { get; set; } = "bash";
 
     /// <summary>
+    /// Name of the CLI binary the Docker CLI driver should invoke. Defaults to
+    /// <c>docker</c>. Set to a docker-compatible CLI (e.g. <c>finch</c> or <c>nerdctl</c>)
+    /// to drive that engine without aliasing it to <c>docker</c>.
+    /// </summary>
+    public string BinaryName { get; set; }
+
+    /// <summary>
+    /// Custom directories to search for the CLI binary. When null or empty, the
+    /// <c>PATH</c> environment variable is used.
+    /// </summary>
+    public string[] SearchPaths { get; set; }
+
+    /// <summary>
     /// Configuration for automatic Podman machine start.
     /// When non-null, the Podman driver pack will ensure a machine
     /// is running during initialization.


### PR DESCRIPTION
Fixes #315

## Request
Override the binary the library invokes so docker-compatible CLIs (finch, nerdctl, …) can be used without aliasing them to `docker`.

## What was missing
v3 added a native Podman driver, but the **Docker CLI** driver still hardcoded the binary name (`docker`/`docker.exe`) in `DockerBinariesResolver`, and there was no public override.

## Change
- `BinaryConfiguration.BinaryName` (default `"docker"`) and `DriverContext.BinaryName` + `DriverContext.SearchPaths`.
- `DockerBinariesResolver` resolves the configured binary name and always maps the matched client to `DockerBinaryType.DockerClient`, so engines whose name doesn't translate to a known type (finch, nerdctl) are still found as `MainDockerClient`. Docker Desktop's `dockercli.exe` special-case is preserved for `"docker"` only.
- `DockerCliDriverPack` threads `BinaryName`/`SearchPaths` (and the consumer logger factory) from the context into the resolver.
- `IDockerCliDriverBuilder.WithBinary(string binaryName, params string[] searchPaths)`:

```csharp
FluentDockerKernel.Create()
  .WithDockerCli("finch", d => d.WithBinary("finch").AsDefault())
  .Build();
```

Documented as **best-effort** docker-CLI compatibility — engines differ on a few global flags (e.g. `-H`/`--tlsverify`) — not a certified finch driver.

## Tests
`DockerBinariesResolverCustomBinaryTests`: finch/nerdctl resolve as `MainDockerClient`; missing custom binary throws; default stays `"docker"` and still resolves. (Existing resolver tests updated for the new private signature.)

Full unit suite: **3140 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)