### PR TITLE
feat(#326): expose log source (stdout/stderr) via StreamLogEntriesAsync

### DIFF
--- a/FluentDocker.Tests/CoreTests/Driver/DockerApi/DockerApiStreamDriverTests.cs
+++ b/FluentDocker.Tests/CoreTests/Driver/DockerApi/DockerApiStreamDriverTests.cs
@@ -310,6 +310,54 @@ namespace FluentDocker.Tests.CoreTests.Driver.DockerApi
 
     #endregion
 
+    #region StreamLogEntriesAsync (source tagging, issue #326)
+
+    [Fact]
+    public async Task StreamLogEntriesAsync_TagsStdoutAndStderrPerFrame()
+    {
+      var f1 = CreateMultiplexedFrame(1, "out-line");
+      var f2 = CreateMultiplexedFrame(2, "err-line");
+      var combined = new byte[f1.Length + f2.Length];
+      Array.Copy(f1, 0, combined, 0, f1.Length);
+      Array.Copy(f2, 0, combined, f1.Length, f2.Length);
+
+      var (driver, mock) = CreateDriver();
+      mock.SetupStreamBytes("/containers/src1/logs", combined);
+
+      var entries = new List<LogEntry>();
+      await foreach (var entry in driver.StreamLogEntriesAsync(Ctx, "src1",
+          new StreamLogsConfig { Follow = false }, cancellationToken: TestContext.Current.CancellationToken))
+      {
+        entries.Add(entry);
+      }
+
+      Assert.Equal(2, entries.Count);
+      Assert.Equal(LogStreamSource.Stdout, entries[0].Source);
+      Assert.Equal("out-line", entries[0].Line);
+      Assert.Equal(LogStreamSource.Stderr, entries[1].Source);
+      Assert.Equal("err-line", entries[1].Line);
+    }
+
+    [Fact]
+    public async Task StreamLogEntriesAsync_RawTtyStream_DefaultsToStdout()
+    {
+      // Fewer than 8 bytes triggers the raw/TTY fallback path.
+      var (driver, mock) = CreateDriver();
+      mock.SetupStream("/containers/src2/logs", "ab\ncd");
+
+      var entries = new List<LogEntry>();
+      await foreach (var entry in driver.StreamLogEntriesAsync(Ctx, "src2",
+          new StreamLogsConfig { Follow = false }, cancellationToken: TestContext.Current.CancellationToken))
+      {
+        entries.Add(entry);
+      }
+
+      Assert.NotEmpty(entries);
+      Assert.All(entries, e => Assert.Equal(LogStreamSource.Stdout, e.Source));
+    }
+
+    #endregion
+
     #region Multiplexed Frame Helpers
 
     /// <summary>

--- a/FluentDocker/Drivers/Docker/Api/Components/DockerApiStreamDriver.cs
+++ b/FluentDocker/Drivers/Docker/Api/Components/DockerApiStreamDriver.cs
@@ -31,7 +31,32 @@ namespace FluentDocker.Drivers.Docker.Api.Components
         StreamLogsConfig config = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-      config ??= new StreamLogsConfig();
+      await foreach (var entry in StreamEntriesAsync(containerId, config, cancellationToken)
+          .ConfigureAwait(false))
+      {
+        yield return entry.Line;
+      }
+    }
+
+    /// <summary>
+    /// Streams source-tagged log entries. The originating stream (stdout/stderr) is taken
+    /// from the Docker multiplexed stream header, which the line-based <see cref="StreamLogsAsync"/>
+    /// discards.
+    /// </summary>
+    public async IAsyncEnumerable<LogEntry> StreamLogEntriesAsync(
+        DriverContext context, string containerId,
+        StreamLogsConfig config = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+      await foreach (var entry in StreamEntriesAsync(containerId, config, cancellationToken)
+          .ConfigureAwait(false))
+      {
+        yield return entry;
+      }
+    }
+
+    private static string BuildLogsPath(string containerId, StreamLogsConfig config)
+    {
       var path = $"/containers/{Uri.EscapeDataString(containerId)}/logs?" +
           $"follow={config.Follow.ToString().ToLower()}" +
           $"&stdout={config.Stdout.ToString().ToLower()}" +
@@ -44,6 +69,15 @@ namespace FluentDocker.Drivers.Docker.Api.Components
         path += $"&since={Uri.EscapeDataString(config.Since)}";
       if (!string.IsNullOrEmpty(config.Until))
         path += $"&until={Uri.EscapeDataString(config.Until)}";
+      return path;
+    }
+
+    private async IAsyncEnumerable<LogEntry> StreamEntriesAsync(
+        string containerId, StreamLogsConfig config,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+      config ??= new StreamLogsConfig();
+      var path = BuildLogsPath(containerId, config);
 
       Stream stream;
       try
@@ -61,9 +95,9 @@ namespace FluentDocker.Drivers.Docker.Api.Components
       // Use try/finally to dispose the stream when the caller breaks out.
       try
       {
-        await foreach (var line in ReadMultiplexedStreamAsync(stream, cancellationToken))
+        await foreach (var entry in ReadMultiplexedStreamAsync(stream, cancellationToken))
         {
-          yield return line;
+          yield return entry;
         }
       }
       finally
@@ -197,11 +231,11 @@ namespace FluentDocker.Drivers.Docker.Api.Components
     #region Multiplexed Stream Reader
 
     /// <summary>
-    /// Reads Docker multiplexed stream format.
+    /// Reads Docker multiplexed stream format, tagging each line with its source stream.
     /// Header: [stream_type:1][0:3][size:4 big-endian] followed by payload.
     /// stream_type: 0=stdin, 1=stdout, 2=stderr.
     /// </summary>
-    private static async IAsyncEnumerable<string> ReadMultiplexedStreamAsync(
+    private static async IAsyncEnumerable<LogEntry> ReadMultiplexedStreamAsync(
         Stream stream, [EnumeratorCancellation] CancellationToken ct)
     {
       var header = new byte[8];
@@ -218,7 +252,8 @@ namespace FluentDocker.Drivers.Docker.Api.Components
 
         if (bytesRead < 8)
         {
-          // Possibly a raw (TTY) stream -- try reading as plain text
+          // Possibly a raw (TTY) stream -- try reading as plain text.
+          // Raw streams carry no source byte, so everything is treated as stdout.
           if (bytesRead > 0)
           {
             var partial = Encoding.UTF8.GetString(header, 0, bytesRead);
@@ -228,11 +263,13 @@ namespace FluentDocker.Drivers.Docker.Api.Components
             foreach (var line in (partial + rest).Split('\n'))
             {
               if (!string.IsNullOrEmpty(line))
-                yield return line;
+                yield return new LogEntry { Source = LogStreamSource.Stdout, Line = line };
             }
           }
           yield break;
         }
+
+        var source = MapSource(header[0]);
 
         var frameSize = (header[4] << 24) | (header[5] << 16) |
             (header[6] << 8) | header[7];
@@ -249,10 +286,17 @@ namespace FluentDocker.Drivers.Docker.Api.Components
         foreach (var line in text.Split('\n'))
         {
           if (!string.IsNullOrEmpty(line))
-            yield return line;
+            yield return new LogEntry { Source = source, Line = line };
         }
       }
     }
+
+    private static LogStreamSource MapSource(byte streamType) => streamType switch
+    {
+      0 => LogStreamSource.Stdin,
+      2 => LogStreamSource.Stderr,
+      _ => LogStreamSource.Stdout,
+    };
 
     // ReadExactAsync is inherited from DockerApiDriverBase
 

--- a/FluentDocker/Drivers/IStreamDriver.cs
+++ b/FluentDocker/Drivers/IStreamDriver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentDocker.Common;
@@ -30,6 +31,30 @@ namespace FluentDocker.Drivers
         string containerId,
         StreamLogsConfig config = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Streams container logs as <see cref="LogEntry"/> values tagged with the originating
+    /// stream (stdout/stderr). The Docker Engine API driver populates the real source from the
+    /// multiplexed stream header; CLI-based drivers, which cannot distinguish the streams at
+    /// the line level, tag every line as <see cref="LogStreamSource.Stdout"/> by default.
+    /// </summary>
+    /// <param name="context">Driver context</param>
+    /// <param name="containerId">Container ID or name</param>
+    /// <param name="config">Stream configuration</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Async enumerable of source-tagged log entries</returns>
+    async IAsyncEnumerable<LogEntry> StreamLogEntriesAsync(
+        DriverContext context,
+        string containerId,
+        StreamLogsConfig config = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+      await foreach (var line in StreamLogsAsync(context, containerId, config, cancellationToken)
+          .WithCancellation(cancellationToken).ConfigureAwait(false))
+      {
+        yield return new LogEntry { Source = LogStreamSource.Stdout, Line = line };
+      }
+    }
 
     /// <summary>
     /// Streams system events.
@@ -70,6 +95,35 @@ namespace FluentDocker.Drivers
         string containerId,
         AttachConfig config = null,
         CancellationToken cancellationToken = default);
+  }
+
+  /// <summary>
+  /// Identifies which container stream a log line originated from. Values match the Docker
+  /// multiplexed stream-type byte (0 = stdin, 1 = stdout, 2 = stderr).
+  /// </summary>
+  public enum LogStreamSource
+  {
+    /// <summary>The container's standard input.</summary>
+    Stdin = 0,
+    /// <summary>The container's standard output.</summary>
+    Stdout = 1,
+    /// <summary>The container's standard error.</summary>
+    Stderr = 2
+  }
+
+  /// <summary>
+  /// A single container log line together with the stream it came from.
+  /// </summary>
+  public sealed class LogEntry
+  {
+    /// <summary>The stream the line was written to.</summary>
+    public LogStreamSource Source { get; set; }
+
+    /// <summary>The log line (without the trailing newline).</summary>
+    public string Line { get; set; }
+
+    /// <summary>Optional timestamp when timestamps are requested in the stream config.</summary>
+    public DateTime? Timestamp { get; set; }
   }
 
   #region Config Types


### PR DESCRIPTION
Fixes #326

## Request
Know whether each container log entry came from **stdout** or **stderr**.

## What was missing
Every log API returned plain strings. The Docker Engine API multiplexed stream actually carries the source as header byte 0 (`1`=stdout, `2`=stderr), but `ReadMultiplexedStreamAsync` discarded it.

## Change
- New `LogStreamSource` enum (`Stdin=0/Stdout=1/Stderr=2`, matching the protocol byte) and `LogEntry { Source, Line, Timestamp }`.
- `IStreamDriver.StreamLogEntriesAsync(...)` added as a **default interface method** — backward compatible: the default tags every line `Stdout`, so existing and external implementers keep compiling/working with no changes.
- `DockerApiStreamDriver` **overrides** it: the multiplexed reader now yields `LogEntry` with the real per-frame source. `StreamLogsAsync` delegates to the same reader and projects `.Line`, so its behavior is unchanged. The raw/TTY fallback defaults to `Stdout`.

CLI/Podman drivers inherit the default (lines tagged `Stdout`) — the CLI can't distinguish the streams at the line level; this limitation is documented on the interface method.

```csharp
await foreach (var entry in streamDriver.StreamLogEntriesAsync(ctx, id))
    Console.WriteLine($"[{entry.Source}] {entry.Line}");
```

## Tests
`DockerApiStreamDriverTests`: mixed stdout/stderr frames map to the correct per-entry `Source`; raw/TTY stream defaults to `Stdout`.

Full unit suite: **3137 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)