### PR TITLE
fix(#283): make ExecuteOnRunning run each command once, after readiness

### DIFF
--- a/FluentDocker.Tests/CoreTests/BuilderTests/BuilderContainerTests.LifecycleExec.cs
+++ b/FluentDocker.Tests/CoreTests/BuilderTests/BuilderContainerTests.LifecycleExec.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentDocker.Builders;
+using FluentDocker.Common;
+using FluentDocker.Drivers;
+using FluentDocker.Model.Drivers;
+using Moq;
+using Xunit;
+
+namespace FluentDocker.Tests.CoreTests.BuilderTests
+{
+  /// <summary>
+  /// Tests for ExecuteOnRunning lifecycle execution (issue #283): each command runs as a
+  /// separate command, exactly once, AFTER wait conditions, and failures propagate.
+  /// </summary>
+  public partial class BuilderContainerTests
+  {
+    private void SetupLifecycleBuild() =>
+        MockPack
+            .SetupContainerCreate()
+            .SetupContainerStart()
+            .SetupContainerInspect(running: true)
+            .SetupContainerStop()
+            .SetupContainerRemove();
+
+    [Fact]
+    public async Task ExecuteOnRunning_RunsEachCommandAsSeparateCommand_ExactlyOnce()
+    {
+      SetupLifecycleBuild();
+
+      var execCommands = new List<string>();
+      MockPack.ContainerDriver
+          .Setup(d => d.ExecAsync(
+              It.IsAny<DriverContext>(), It.IsAny<string>(),
+              It.IsAny<ExecConfig>(), It.IsAny<CancellationToken>()))
+          .Callback<DriverContext, string, ExecConfig, CancellationToken>(
+              (_, _, cfg, _) => execCommands.Add(string.Join(" ", cfg.Command)))
+          .ReturnsAsync(CommandResponse<ExecResult>.Ok(new ExecResult { StdOut = "", ExitCode = 0 }));
+
+      using var results = await new Builder()
+          .WithinDriver(DriverId, Kernel)
+          .UseContainer(c => c
+              .UseImage("alpine")
+              .ExecuteOnRunning("first", "second"))
+          .BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+      // Each array element runs as its own command (not joined) and exactly once (no double-exec).
+      Assert.Equal(new[] { "first", "second" }, execCommands);
+    }
+
+    [Fact]
+    public async Task ExecuteOnRunning_RunsAfterWaitConditions()
+    {
+      SetupLifecycleBuild();
+
+      var order = new List<string>();
+      MockPack.ContainerDriver
+          .Setup(d => d.ExecAsync(
+              It.IsAny<DriverContext>(), It.IsAny<string>(),
+              It.IsAny<ExecConfig>(), It.IsAny<CancellationToken>()))
+          .Callback(() => order.Add("exec"))
+          .ReturnsAsync(CommandResponse<ExecResult>.Ok(new ExecResult { StdOut = "", ExitCode = 0 }));
+
+      using var results = await new Builder()
+          .WithinDriver(DriverId, Kernel)
+          .UseContainer(c => c
+              .UseImage("alpine")
+              .Wait((_, _) => { order.Add("wait"); return -1; })
+              .ExecuteOnRunning("after-ready"))
+          .BuildAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+      Assert.Equal(new[] { "wait", "exec" }, order);
+    }
+
+    [Fact]
+    public async Task ExecuteOnRunning_FailingCommand_PropagatesError()
+    {
+      SetupLifecycleBuild();
+
+      MockPack.ContainerDriver
+          .Setup(d => d.ExecAsync(
+              It.IsAny<DriverContext>(), It.IsAny<string>(),
+              It.IsAny<ExecConfig>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync(CommandResponse<ExecResult>.Fail("exec boom", "CONTAINER_EXEC_FAILED"));
+
+      await Assert.ThrowsAsync<DriverException>(async () =>
+          await new Builder()
+              .WithinDriver(DriverId, Kernel)
+              .UseContainer(c => c
+                  .UseImage("alpine")
+                  .ExecuteOnRunning("will-fail"))
+              .BuildAsync(cancellationToken: TestContext.Current.CancellationToken));
+    }
+  }
+}

--- a/FluentDocker/Builders/ContainerBuilder.WaitConditions.cs
+++ b/FluentDocker/Builders/ContainerBuilder.WaitConditions.cs
@@ -103,24 +103,49 @@ namespace FluentDocker.Builders
         return;
 
       _waitConditionsExecuted = true;
-      await ExecuteWaitConditionsAsync(_pendingService, cancellationToken).ConfigureAwait(false);
+      await RunPostStartAsync(_pendingService, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task ExecuteLifecycleHooksAsync(
-        Services.Impl.ContainerService service, ServiceRunningState state,
+    /// <summary>
+    /// Runs the post-start sequence for a started container: setup hooks (CopyToOnStart) first,
+    /// then wait conditions, then ExecuteOnRunning commands. Running Execute hooks AFTER the wait
+    /// conditions means commands fire only once the container is actually ready (issue #283).
+    /// </summary>
+    internal async Task RunPostStartAsync(
+        Services.Impl.ContainerService service, CancellationToken cancellationToken)
+    {
+      await RunRunningLifecycleHooksAsync(service, executeCommands: false, cancellationToken).ConfigureAwait(false);
+      await ExecuteWaitConditionsAsync(service, cancellationToken).ConfigureAwait(false);
+      await RunRunningLifecycleHooksAsync(service, executeCommands: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs Running-triggered lifecycle hooks. When <paramref name="executeCommands"/> is false,
+    /// only setup hooks (CopyToOnStart) run; when true, only ExecuteOnRunning commands run.
+    /// Each element of an Execute hook's command array is executed as a separate command,
+    /// and failures propagate (the v2 contract) rather than being silently swallowed.
+    /// </summary>
+    private async Task RunRunningLifecycleHooksAsync(
+        Services.Impl.ContainerService service, bool executeCommands,
         CancellationToken cancellationToken)
     {
-      var hooks = _lifecycleHooks.Where(h => h.TriggerState == state);
-      foreach (var hook in hooks)
+      foreach (var hook in _lifecycleHooks)
       {
+        if (hook.TriggerState != ServiceRunningState.Running)
+          continue;
+
         switch (hook.Type)
         {
-          case LifecycleHookType.CopyTo:
+          case LifecycleHookType.CopyTo when !executeCommands:
             await service.CopyToAsync(hook.ContainerPath,
                 File.ReadAllBytes(hook.HostPath), cancellationToken).ConfigureAwait(false);
             break;
-          case LifecycleHookType.Execute:
-            await service.ExecuteAsync(string.Join(" ", hook.Command), cancellationToken).ConfigureAwait(false);
+          case LifecycleHookType.Execute when executeCommands:
+            if (hook.Command != null)
+            {
+              foreach (var command in hook.Command)
+                await service.ExecuteAsync(command, cancellationToken).ConfigureAwait(false);
+            }
             break;
         }
       }

--- a/FluentDocker/Builders/ContainerBuilder.cs
+++ b/FluentDocker/Builders/ContainerBuilder.cs
@@ -460,9 +460,8 @@ namespace FluentDocker.Builders
         {
           await service.StartAsync(cancellationToken).ConfigureAwait(false);
           await WaitForContainerRunningAsync(driver, context, response.Data.Id, cancellationToken).ConfigureAwait(false);
-          await ExecuteLifecycleHooksAsync(service, ServiceRunningState.Running, cancellationToken).ConfigureAwait(false);
-          await ExecuteWaitConditionsAsync(service, cancellationToken).ConfigureAwait(false);
           _waitConditionsExecuted = true;
+          await RunPostStartAsync(service, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/FluentDocker/Services/Impl/ContainerService.cs
+++ b/FluentDocker/Services/Impl/ContainerService.cs
@@ -132,7 +132,9 @@ namespace FluentDocker.Services.Impl
 
       UpdateState(ServiceRunningState.Running);
       await ExecuteHooksAsync(ServiceRunningState.Running).ConfigureAwait(false);
-      await ExecuteLifecycleHooksAsync(ServiceRunningState.Running, cancellationToken).ConfigureAwait(false);
+      // Running lifecycle hooks (CopyToOnStart / ExecuteOnRunning) are orchestrated by the
+      // builder so they run exactly once and Execute hooks fire AFTER wait conditions. They
+      // are intentionally NOT run here to avoid double execution and premature ordering.
     }
 
     public async Task PauseAsync(CancellationToken cancellationToken = default)
@@ -406,9 +408,11 @@ namespace FluentDocker.Services.Impl
               break;
 
             case LifecycleHookType.Execute:
-              if (hook.Command?.Length > 0)
+              // Each element is a separate command (matches the v2 contract).
+              if (hook.Command != null)
               {
-                await ExecuteAsync(string.Join(" ", hook.Command), cancellationToken).ConfigureAwait(false);
+                foreach (var command in hook.Command)
+                  await ExecuteAsync(command, cancellationToken).ConfigureAwait(false);
               }
               break;
           }


### PR DESCRIPTION
Fixes #283

## The bug
`ExecuteOnRunning` (and `ExecuteOnDisposing`) silently did the wrong thing. I traced three distinct defects in the v3 code path:

1. **Semantic regression.** The `params string[]` was collapsed with `string.Join(" ", hook.Command)` and run as **one** command. The reporter passed an array of full SQL/shell commands, which became a single malformed command — so the `touch` marker never appeared and the other scripts never ran.
2. **Double execution + wrong ordering.** Hooks ran once inside `ContainerService.StartAsync` *and* again in the builder — both **before** the wait conditions. So `ExecuteOnRunning` fired before `WaitForMessageInLog` completed (i.e. before MSSQL finished recovery).
3. **Silent failure.** Exec errors were caught and only logged, so the user "got no errors" even when a command failed.

## Fix
- **Per-element execution** (restores the v2 contract): each element of the array runs as its own command, in both the running and dispose paths.
- **Single owner + correct ordering.** `StartAsync` no longer runs Running lifecycle hooks. The builder now drives them via `RunPostStartAsync`: `CopyToOnStart` → **wait conditions** → `ExecuteOnRunning`. So commands fire exactly once, only after the container is actually ready. The no-links and linked-container paths are unified through the same method.
- **Errors propagate.** A failing `ExecuteOnRunning` command now throws `DriverException` instead of being swallowed.

> Note: this changes `ExecuteOnRunning`/`ExecuteOnDisposing` semantics so that **each string argument is a separate command** (the v2 behavior), and moves Running-hook execution out of `StartAsync` into the build pipeline.

## Tests
`BuilderContainerTests.LifecycleExec`: each command runs separately and exactly once (no double-exec, no join); `ExecuteOnRunning` runs **after** wait conditions; a failing command propagates.

Full unit suite: **3138 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)